### PR TITLE
Run go mod tidy after renovate to cleanup go.sum and go.mod

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,3 +19,6 @@ jobs:
         uses: rinchsan/renovate-config-validator@b87b6441b539cd7bcf6e684fb6cac65b81e84085 # renovate: tag=v0.0.10
         with:
           pattern: 'renovate.json'
+      - name: GO Mod Tidy
+        run: |
+          go mod tidy


### PR DESCRIPTION
This works in my local test to fix the issue we are getting on the prs from renovate but I have no way to test it will work in the full github workflow so i guess is worth a try , we can revert if it does not