### PR TITLE
Allow output filenames to have yml suffix

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -29,10 +29,9 @@ const (
 
 func init() {
 	RootCmd.AddCommand(showCmd)
-	showCmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format.  Supported values are: json, yaml")
+	showCmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format. Supported values are: json, yaml, yml. yaml and yml produce the same content but use the respective file suffix.")
 	showCmd.PersistentFlags().String(flagExportDir, "", "Split yaml stream into multiple files and write files into a directory. If the directory exists it must be empty.")
 	showCmd.PersistentFlags().String(flagExportFileNameFormat, kubecfg.DefaultFileNameFormat, "Go template expression used to render path names for resources.")
-
 }
 
 var showCmd = &cobra.Command{

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -64,6 +64,10 @@ func TestShow(t *testing.T) {
 			err = yaml.Unmarshal([]byte(text), &ret)
 			return
 		},
+		"yml": func(text string) (ret interface{}, err error) {
+			err = yaml.Unmarshal([]byte(text), &ret)
+			return
+		},
 	}
 
 	// Use the fact that JSON is also valid YAML ..

--- a/pkg/kubecfg/show.go
+++ b/pkg/kubecfg/show.go
@@ -63,7 +63,8 @@ var (
 
 // ShowCmd represents the show subcommand
 type ShowCmd struct {
-	// OutputFormat is either "yaml" or "json"
+	// OutputFormat is "yaml", "yml", or "json".
+	// "yaml" and "yml" are equivalent other than writing out files with that respective suffix.
 	OutputFormat string
 	// ExportDir is an optional name of a directory. If not set, the show command
 	// will output all the resource concatenated to stdout. Otherwise, it will
@@ -150,7 +151,7 @@ func (c ShowCmd) renderObject(idx int, obj *unstructured.Unstructured, out io.Wr
 	}
 
 	switch c.OutputFormat {
-	case "yaml":
+	case "yaml", "yml":
 		fmt.Fprintln(out, "---")
 		o, err := k8sToJSONObject(obj)
 		if err != nil {

--- a/pkg/kubecfg/show_test.go
+++ b/pkg/kubecfg/show_test.go
@@ -69,12 +69,14 @@ func TestShowExport(t *testing.T) {
 	}
 
 	testCases := []struct {
-		testObjects []*unstructured.Unstructured
-		format      string
-		want        []string
+		testObjects  []*unstructured.Unstructured
+		outputFormat string
+		nameFormat   string
+		want         []string
 	}{
 		{
 			testObjects,
+			"yaml",
 			DefaultFileNameFormat,
 			[]string{
 				"tests-v1alpha1.Dummy-default.foo.yaml:7fb7dfcbf33096d74bd582cb8d827c17372625b412f3a022c1f849dd1fc5a70a",
@@ -83,6 +85,16 @@ func TestShowExport(t *testing.T) {
 		},
 		{
 			testObjects,
+			"yml",
+			DefaultFileNameFormat,
+			[]string{
+				"tests-v1alpha1.Dummy-default.foo.yml:7fb7dfcbf33096d74bd582cb8d827c17372625b412f3a022c1f849dd1fc5a70a",
+				"tests-v1alpha1.Dummy-myns.bar.yml:f0e39aa44d1e55fb8b06a05c97f6c2082e484c5a64bc9f766e26675346ca26ff",
+			},
+		},
+		{
+			testObjects,
+			"yaml",
 			`{{default "default" .metadata.namespace}}/{{.apiVersion}}.{{.kind}}/{{.metadata.name}}`,
 			[]string{
 				"default/tests-v1alpha1.Dummy/foo.yaml:7fb7dfcbf33096d74bd582cb8d827c17372625b412f3a022c1f849dd1fc5a70a",
@@ -91,6 +103,7 @@ func TestShowExport(t *testing.T) {
 		},
 		{
 			testObjects,
+			"yaml",
 			`{{resourceIndex . | printf "%04d" }}-{{.apiVersion}}.{{.kind}}-{{default "default" .metadata.namespace}}.{{.metadata.name}}`,
 			[]string{
 				"0000-tests-v1alpha1.Dummy-default.foo.yaml:7fb7dfcbf33096d74bd582cb8d827c17372625b412f3a022c1f849dd1fc5a70a",
@@ -108,7 +121,7 @@ func TestShowExport(t *testing.T) {
 				os.RemoveAll(tmpdir)
 			})
 
-			c, err := NewShowCmd("yaml", tmpdir, tc.format)
+			c, err := NewShowCmd(tc.outputFormat, tmpdir, tc.nameFormat)
 			if err != nil {
 				t.Error(t)
 			}


### PR DESCRIPTION
In our internal project, we have almost 5000 individual YAML files that
we generate. For historic reasons, we continue to name the files .yml
instead of .yaml.

By enabling kubecfg to write the files with a .yml suffix, we can
produce these files for our CI/CD pipeline measurably faster.

I used hyperfine to benchmark the current mode (my build of kubecfg, do
not specify --format, followed by find | read | mv), vs. the same build
of kubecfg with --format=yml, no call to find.

Benchmark #1: GENMODE=current make generate
  Time (mean ± σ):     13.384 s ±  0.459 s    [User: 79.086 s, System: 19.813 s]
  Range (min … max):   12.775 s … 14.280 s    10 runs

Benchmark #2: GENMODE=newkubecfg make generate
  Time (mean ± σ):     11.166 s ±  0.216 s    [User: 73.907 s, System: 9.905 s]
  Range (min … max):   10.858 s … 11.544 s    10 runs

Summary
  'GENMODE=newkubecfg make generate' ran
    1.20 ± 0.05 times faster than 'GENMODE=current make generate'