### PR TITLE
Use --export-filename-extension instead of special casing -o yml

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -16,22 +16,25 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
+	"fmt"
 
 	"github.com/kubecfg/kubecfg/pkg/kubecfg"
+	"github.com/spf13/cobra"
 )
 
 const (
 	flagFormat               = "format"
 	flagExportDir            = "export-dir"
 	flagExportFileNameFormat = "export-filename-format"
+	flagExportFileNameExt    = "export-filename-extension"
 )
 
 func init() {
 	RootCmd.AddCommand(showCmd)
-	showCmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format. Supported values are: json, yaml, yml. yaml and yml produce the same content but use the respective file suffix.")
+	showCmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format.  Supported values are: json, yaml")
 	showCmd.PersistentFlags().String(flagExportDir, "", "Split yaml stream into multiple files and write files into a directory. If the directory exists it must be empty.")
 	showCmd.PersistentFlags().String(flagExportFileNameFormat, kubecfg.DefaultFileNameFormat, "Go template expression used to render path names for resources.")
+	showCmd.PersistentFlags().String(flagExportFileNameExt, "", fmt.Sprintf("Override the file extension used when creating filenames when using %s", flagExportFileNameFormat))
 }
 
 var showCmd = &cobra.Command{
@@ -53,8 +56,12 @@ var showCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		exportFileNameExt, err := flags.GetString(flagExportFileNameExt)
+		if err != nil {
+			return err
+		}
 
-		c, err := kubecfg.NewShowCmd(outputFormat, exportDir, exportFileNameFormat)
+		c, err := kubecfg.NewShowCmd(outputFormat, exportDir, exportFileNameFormat, exportFileNameExt)
 		if err != nil {
 			return err
 		}

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -64,10 +64,6 @@ func TestShow(t *testing.T) {
 			err = yaml.Unmarshal([]byte(text), &ret)
 			return
 		},
-		"yml": func(text string) (ret interface{}, err error) {
-			err = yaml.Unmarshal([]byte(text), &ret)
-			return
-		},
 	}
 
 	// Use the fact that JSON is also valid YAML ..

--- a/pkg/kubecfg/show_test.go
+++ b/pkg/kubecfg/show_test.go
@@ -72,12 +72,14 @@ func TestShowExport(t *testing.T) {
 		testObjects  []*unstructured.Unstructured
 		outputFormat string
 		nameFormat   string
+		ext          string
 		want         []string
 	}{
 		{
 			testObjects,
 			"yaml",
 			DefaultFileNameFormat,
+			"",
 			[]string{
 				"tests-v1alpha1.Dummy-default.foo.yaml:7fb7dfcbf33096d74bd582cb8d827c17372625b412f3a022c1f849dd1fc5a70a",
 				"tests-v1alpha1.Dummy-myns.bar.yaml:f0e39aa44d1e55fb8b06a05c97f6c2082e484c5a64bc9f766e26675346ca26ff",
@@ -85,8 +87,9 @@ func TestShowExport(t *testing.T) {
 		},
 		{
 			testObjects,
-			"yml",
+			"yaml",
 			DefaultFileNameFormat,
+			"yml",
 			[]string{
 				"tests-v1alpha1.Dummy-default.foo.yml:7fb7dfcbf33096d74bd582cb8d827c17372625b412f3a022c1f849dd1fc5a70a",
 				"tests-v1alpha1.Dummy-myns.bar.yml:f0e39aa44d1e55fb8b06a05c97f6c2082e484c5a64bc9f766e26675346ca26ff",
@@ -96,6 +99,7 @@ func TestShowExport(t *testing.T) {
 			testObjects,
 			"yaml",
 			`{{default "default" .metadata.namespace}}/{{.apiVersion}}.{{.kind}}/{{.metadata.name}}`,
+			"",
 			[]string{
 				"default/tests-v1alpha1.Dummy/foo.yaml:7fb7dfcbf33096d74bd582cb8d827c17372625b412f3a022c1f849dd1fc5a70a",
 				"myns/tests-v1alpha1.Dummy/bar.yaml:f0e39aa44d1e55fb8b06a05c97f6c2082e484c5a64bc9f766e26675346ca26ff",
@@ -105,6 +109,7 @@ func TestShowExport(t *testing.T) {
 			testObjects,
 			"yaml",
 			`{{resourceIndex . | printf "%04d" }}-{{.apiVersion}}.{{.kind}}-{{default "default" .metadata.namespace}}.{{.metadata.name}}`,
+			"",
 			[]string{
 				"0000-tests-v1alpha1.Dummy-default.foo.yaml:7fb7dfcbf33096d74bd582cb8d827c17372625b412f3a022c1f849dd1fc5a70a",
 				"0001-tests-v1alpha1.Dummy-myns.bar.yaml:f0e39aa44d1e55fb8b06a05c97f6c2082e484c5a64bc9f766e26675346ca26ff",
@@ -121,7 +126,7 @@ func TestShowExport(t *testing.T) {
 				os.RemoveAll(tmpdir)
 			})
 
-			c, err := NewShowCmd(tc.outputFormat, tmpdir, tc.nameFormat)
+			c, err := NewShowCmd(tc.outputFormat, tmpdir, tc.nameFormat, tc.ext)
 			if err != nil {
 				t.Error(t)
 			}
@@ -162,7 +167,7 @@ func TestShowExportNonEmpty(t *testing.T) {
 		os.RemoveAll(tmpdir)
 	})
 
-	c, err := NewShowCmd("yaml", tmpdir, DefaultFileNameFormat)
+	c, err := NewShowCmd("yaml", tmpdir, DefaultFileNameFormat, "")
 	if err != nil {
 		t.Error(t)
 	}
@@ -195,7 +200,7 @@ func TestShowOrder(t *testing.T) {
 		},
 	}
 
-	c, err := NewShowCmd("yaml", "", DefaultFileNameFormat)
+	c, err := NewShowCmd("yaml", "", DefaultFileNameFormat, "")
 	if err != nil {
 		t.Error(t)
 	}


### PR DESCRIPTION
The more I think about it, the less I like using `-o yml` to represent yaml but with a different extension.
What if you want `*.YAML` extension or `.jsn` ?
More importantly I'm worried about forgetting to treat `yml` and `yaml` equivalently in the kubecfg internals.

The root issue is that `--export-filename-format` doesn't include the extension. This is in order to support outputting `.yaml` and `.json` files with `--export-dir` .

We should have added the extension as variable that can be referenced in the filename format.

Unfortunately we cannot add this and maintain backward compatibility.

This PR adds a new flag `-export-filename-extension` to override the extension.
Controlling the filename extension is quite a niche feature, so I think that adding a new flag is acceptable.

This PR effectively reverts #65
