### PR TITLE
Garbage collect only the 'preferred' version of resources

### DIFF
--- a/pkg/kubecfg/update.go
+++ b/pkg/kubecfg/update.go
@@ -452,7 +452,7 @@ func gcDelete(ctx context.Context, client dynamic.Interface, mapper meta.RESTMap
 }
 
 func walkObjects(ctx context.Context, client dynamic.Interface, disco discovery.DiscoveryInterface, listopts metav1.ListOptions, callback func(runtime.Object) error) error {
-	rsrclists, err := disco.ServerResources()
+	rsrclists, err := disco.ServerPreferredResources()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously we would garbage collect a stale object by deleting it
through every API group and version through which it appeared.  In
practice, every version after the first one returned 'not found',
which was silently ignored.

Now we walk only the 'preferred' versions of each API group when
looking for stale objects.

As well as making fewer apiserver calls, this should avoid triggering
(safe but noisy) 'deprecated' warnings when we use old API versions.

Fixes #30.