### PR TITLE
Add eval command

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -1,0 +1,78 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/kubecfg/kubecfg/pkg/kubecfg"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	flagExpr     = "expr"
+	flagShowKeys = "show-keys"
+)
+
+func init() {
+	RootCmd.AddCommand(evalCmd)
+	evalCmd.PersistentFlags().StringP(flagExpr, "e", "", "jsonnet expression to evaluate")
+	evalCmd.PersistentFlags().BoolP(flagShowKeys, "k", false, "instead of rendering an object, list it's keys")
+	evalCmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format.  Supported values are: json, yaml")
+}
+
+var evalCmd = &cobra.Command{
+	Use:   "eval",
+	Short: "eval jsonnet expression",
+	Args:  cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		alpha := viper.GetBool(flagAlpha)
+		if !alpha {
+			return fmt.Errorf("eval is an alpha feature, please use --alpha")
+		}
+
+		flags := cmd.Flags()
+		var err error
+		c := kubecfg.EvalCmd{}
+
+		c.Expr, err = flags.GetString(flagExpr)
+		if err != nil {
+			return err
+		}
+
+		c.Format, err = flags.GetString(flagFormat)
+		if err != nil {
+			return err
+		}
+
+		c.ShowKeys, err = flags.GetBool(flagShowKeys)
+		if err != nil {
+			return err
+		}
+
+		vm, err := JsonnetVM(cmd)
+		if err != nil {
+			return err
+		}
+
+		if len(args) < 1 {
+			return fmt.Errorf("jsonent filename required")
+		}
+
+		return c.Run(cmd.Context(), vm, args[0])
+	},
+}

--- a/pkg/kubecfg/eval.go
+++ b/pkg/kubecfg/eval.go
@@ -1,0 +1,58 @@
+package kubecfg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/go-jsonnet"
+	"github.com/kubecfg/kubecfg/utils"
+	"github.com/kubecfg/yaml/v2"
+)
+
+// EvalCmd represents the eval subcommand
+type EvalCmd struct {
+	Expr     string
+	ShowKeys bool
+	Format   string
+}
+
+func (c EvalCmd) Run(ctx context.Context, vm *jsonnet.VM, path string) error {
+	expr := c.Expr
+	if expr == "" {
+		expr = "$"
+	}
+	pathURL, err := utils.PathToFileURL(path)
+	if err != nil {
+		return err
+	}
+	eval := fmt.Sprintf("((import %q) { Z____expr__Z_:: %s}).Z____expr__Z_", pathURL, expr)
+
+	if c.ShowKeys {
+		eval = fmt.Sprintf("std.objectFields(%s)", eval)
+	}
+
+	jsonstr, err := vm.EvaluateAnonymousSnippet(path, eval)
+	if err != nil {
+		return err
+	}
+
+	switch c.Format {
+	case "json":
+		fmt.Println(jsonstr)
+	case "yaml":
+		var jsontree interface{}
+		if err := json.Unmarshal([]byte(jsonstr), &jsontree); err != nil {
+			return err
+		}
+		b, err := yaml.Marshal(jsontree)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+	default:
+		return fmt.Errorf("unsupported format %q", c.Format)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Demo:

```console

$ export KUBECFG_ALPHA=true # or pass the --alpha flag
$ ./kubecfg eval ./examples/guestbook.jsonnet  | head
frontend:
  deploy:
    apiVersion: apps/v1beta2
    kind: Deployment
    metadata:
      annotations: {}
      labels:
        name: frontend
      name: frontend
    spec:
$ ./kubecfg eval ./examples/guestbook.jsonnet  -k    
- frontend
- master
- slave

$ ./kubecfg eval ./examples/guestbook.jsonnet -e $.master -k
- deploy
- svc

$ ./kubecfg eval ./examples/guestbook.jsonnet -e $.master.svc
apiVersion: v1
kind: Service
metadata:
  annotations: {}
  labels:
    name: redis-master
  name: redis-master
spec:
  ports:
  - port: 6379
    targetPort: 6379
  selector:
    name: redis-master
  type: ClusterIP
```