### PR TITLE
Fish completion

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -66,6 +66,10 @@ var completionCmd = &cobra.Command{
 			if err := RootCmd.GenZshCompletion(out); err != nil {
 				return err
 			}
+		case "fish":
+			if err := RootCmd.GenFishCompletion(out, true); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("Unknown shell %q, try --%s", shell, flagShell)
 		}

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -11,6 +11,8 @@ func TestGuessShell(t *testing.T) {
 		{"/bin/bash", "bash"},
 		{"/usr/bin/zsh", "zsh"},
 		{"/usr/bin/zsh5", "zsh"},
+		{"/bin/fish", "fish"},
+		{"/usr/bin/fish", "fish"},
 	} {
 		if result := guessShell(test[0]); result != test[1] {
 			t.Errorf("Guessed %q instead of %q from %q", result, test[1], test[0])


### PR DESCRIPTION
Might as well include this, since it's supported. I wanted to add fish completion to the AUR pkg for kubecfg, so this is a necessary first step.

NOTES:

1. I tried to run `make generate` as advised by the contrib guide, but it doesn't seem to exist. Not sure what's going on there. Maybe those need an update?
2. I ran `make tidy` as a test, and it did produce various changes, notably
```
diff --git a/go.mod b/go.mod
index 193c90c..f1c7448 100644
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 )

 require (
-       cloud.google.com/go v0.100.2 // indirect
```
but I decided not to include this in my PR, insofar as this seems like a pretty trivial change to me. Please advise if this is wrong.

3. I tested `./kubecfg completion > ~/.config/fish/completions/kubecfg.fish` on fish `3.5.1` and it seems to work as expected, but I didn't go deeper than that.