### PR TITLE
renovatebot: run go mod tidy after updating deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
   ],
   "includeForks": false,
   "labels": ["dependencies"],
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "packageRules": [
     {
       "description": "Automerge trivial updates",


### PR DESCRIPTION
Run `go mod tidy` and update import paths after updating go deps.