### PR TITLE
Teach renovatebot how to update github-action go-version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
   ],
   "regexManagers": [
     {
-      "fileMatch": ["^\.github/workflows/.*\.yaml"],
+      "fileMatch": ["^\\.github/workflows/.*\\.yaml$"],
       "matchStrings": ["go-version: *(?<currentValue>.*?)\\n"],
       "depNameTemplate": "go",
       "depTypeTemplate": "golang",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,5 +23,14 @@
       "matchPackagePatterns": ["^kubernetes/", "^k8s\\.gcr\\.io/"],
       "groupName": "Kubernetes packages"
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^\.github/workflows/.*\.yaml"],
+      "matchStrings": ["go-version: *(?<currentValue>.*?)\\n"],
+      "depNameTemplate": "go",
+      "depTypeTemplate": "golang",
+      "datasourceTemplate": "golang-version"
+    }
   ]
 }


### PR DESCRIPTION
This replicates the logic that renovatebot uses to update `go.mod` go version, so should stay in sync.

See the `golang-version` datasource and https://github.com/renovatebot/renovate/blob/3cec44cfa78e37a57c84e6428056787fc00ade7c/lib/modules/manager/gomod/extract.spec.ts#L22-L35