### PR TITLE
Remove ancient use of ldd

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,6 @@ jobs:
 
       - name: Info Binary
         run: |
-          #ldd ./kubecfg || otool -L ./kubecfg # What's the purpose of this ? it currently fail since we don't produce a dynamic executable
           ./kubecfg help
           ./kubecfg version
 


### PR DESCRIPTION
Once upon a time, there was no go-jsonnet, and `kubecfg` used cgo to link against a static (C++) libjsonnet.

When the dinosaurs downloaded this ancient pre-compiled kubecfg binary, it was important that it _was_ statically linked, and did not contain references to external shared libraries that those dinosaurs might not have had locally.   There was a line in the ancient build rituals to help detect and debug such issues.

Remove this long-obsolete reference to the ancient rituals, and let them pass into git history.