### PR TITLE
Relax version syntax in go-version updater

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,8 @@
       "matchStrings": ["go-version: *(?<currentValue>.*?)\\n"],
       "depNameTemplate": "go",
       "depTypeTemplate": "golang",
-      "datasourceTemplate": "golang-version"
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "npm"
     }
   ]
 }


### PR DESCRIPTION
Sigh. I wondered if this mattered - turns out it does.  See `skipReason` in https://app.renovatebot.com/dashboard#github/kubecfg/kubecfg/789631133:

```json
        "packageFile": ".github/workflows/go.yml",
        "deps": [
          {
            "depName": "go",
            "currentValue": "1.17",
            "datasource": "golang-version",
            "depType": "golang",
            "replaceString": "go-version: 1.17\n",
            "depIndex": 0,
            "warnings": [],
            "versioning": "semver",
            "skipReason": "invalid-value",
            "updates": []
          }
        ],
```

`1.17` is not a valid version using the default 'semver' versioning scheme (must be 3 components).

Change to use more relaxed 'npm' version comparisons, again matching what is used in renovatebot `go.mod` updates.