### PR TITLE
Use docker image name without: ghcr.io/kubecfg/kubecfg/kubecfg

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,6 @@ on:
       - main
 
 jobs:
-
   build:
     strategy:
       matrix:
@@ -54,7 +53,7 @@ jobs:
 
       # Only run integration on linux matrix job
       - name: Create k8s Kind Cluster
-        uses:  engineerd/setup-kind@v0.5.0
+        uses: engineerd/setup-kind@v0.5.0
         if: matrix.os == 'ubuntu-latest'
         with:
           version: "v0.11.1"
@@ -76,10 +75,10 @@ jobs:
 
       - if: matrix.os == 'ubuntu-latest'
         uses: imjasonh/setup-ko@v0.6
-      
+
       - name: Build OCI image using ko and push it to ghcr
         if: matrix.os == 'ubuntu-latest'
-        run: ko build
+        run: ko build -B
 
   create_release:
     name: Create Release
@@ -124,4 +123,3 @@ jobs:
           asset_path: kubecfg
           asset_name: kubecfg_${{ runner.os }}_${{ runner.arch }}
           asset_content_type: application/octet-stream
-


### PR DESCRIPTION
Currently we're running `ko build` with default arguments which includes a hash of the import path of the binary in the repo name: [kubecfg/kubecfg-2ba4e5aa7403687d7ea49e0928bad159](https://github.com/orgs/kubecfg/packages/container/package/kubecfg%2Fkubecfg-2ba4e5aa7403687d7ea49e0928bad159)

we want to publish the container with a less confusing image name; the `-B` flag strikes a good balance: it still allows multiple docker images per project but makes the reasonable assumption that we'll name our binaries with unique names within this project. Hence, the image name will become `ghcr.io/kubecfg/kubecfg/kubecfg` (the first kubecfg is the org, the second is the repo name and the third is the binary)