### PR TITLE
Add simple stupid --alpha httpd command

### DIFF
--- a/cmd/httpd.go
+++ b/cmd/httpd.go
@@ -1,0 +1,65 @@
+// Copyright 2017 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/kubecfg/kubecfg/pkg/kubecfg"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	flagListenAddr = "listen-addr"
+)
+
+func init() {
+	RootCmd.AddCommand(httpdCmd)
+	httpdCmd.PersistentFlags().StringP(flagListenAddr, "l", ":8080", "address:port to listen")
+}
+
+var httpdCmd = &cobra.Command{
+	Use:   "httpd",
+	Short: "process https requests with jsonnet",
+	Args:  cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		alpha := viper.GetBool(flagAlpha)
+		if !alpha {
+			return fmt.Errorf("httpd is an alpha feature, please use --alpha")
+		}
+
+		flags := cmd.Flags()
+		var err error
+		c := kubecfg.HttpdCmd{}
+
+		c.ListenAddr, err = flags.GetString(flagListenAddr)
+		if err != nil {
+			return err
+		}
+
+		vm, err := JsonnetVM(cmd)
+		if err != nil {
+			return err
+		}
+
+		if len(args) < 1 {
+			return fmt.Errorf("jsonnet filename required")
+		}
+
+		return c.Run(cmd.Context(), vm, args)
+	},
+}

--- a/pkg/kubecfg/httpd.go
+++ b/pkg/kubecfg/httpd.go
@@ -1,0 +1,60 @@
+package kubecfg
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-jsonnet"
+	"github.com/kubecfg/kubecfg/utils"
+)
+
+// HttpdCmd represents the eval subcommand
+type HttpdCmd struct {
+	ListenAddr string
+}
+
+func evaluateFile(vm *jsonnet.VM, path string) (string, error) {
+	pathURL, err := utils.PathToFileURL(path)
+	if err != nil {
+		return "", err
+	}
+	// TODO(mkm): figure out why vm.EvaluateFile and vm.EvaluateAnonymousSnippet don't work with our custom importers.
+	snippet := fmt.Sprintf("(import %q)", path)
+	jsonstr, err := vm.EvaluateSnippet(pathURL, snippet)
+	if err != nil {
+		return "", err
+	}
+	return jsonstr, nil
+}
+
+func (c HttpdCmd) Run(ctx context.Context, vm *jsonnet.VM, paths []string) error {
+	for _, path := range paths {
+		base := strings.TrimSuffix(path, ".jsonnet")
+		http.HandleFunc(fmt.Sprint("/", base), func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "Can't read body", http.StatusInternalServerError)
+				return
+			}
+			vm.TLACode("request", string(body))
+			result, err := evaluateFile(vm, path)
+
+			if err != nil {
+				http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Printf("Printing results: %q\n", result)
+			fmt.Fprint(w, result)
+		})
+	}
+
+	return http.ListenAndServe(c.ListenAddr, nil)
+}


### PR DESCRIPTION
Implements a "http server" where the request handler is implemented in jsonnet.

 The idea seems a bit crazy, but it's actually a quite dope way to implement k8s controllers by implementing [metacontroller](https://metacontroller.github.io/metacontroller/intro.html) hooks in jsonnet.


Example

```console
$ cat /tmp/ugo.jsonnet 
function(request) {
  got: request,
  message: 'ok',
}
$ make && ./kubecfg --alpha -J /tmp httpd ugo.jsonnet
CGO_ENABLED=0 go build  -tags netgo -installsuffix netgo -ldflags="-X main.version=dev-2022-12-20T15:52:22+0100-5ab1d34f " .
```

```console
$ curl  -d'{"bar":"baz"}' http://localhost:8080/ugo
{
   "got": {
      "bar": "baz"
   },
   "message": "ok"
}
```

This is just an alpha command meant for public experimentation, but no guarantees are made on API stability