### PR TITLE
Allow URL in CLI arguments

### DIFF
--- a/pkg/kubecfg/eval.go
+++ b/pkg/kubecfg/eval.go
@@ -23,7 +23,7 @@ func (c EvalCmd) Run(ctx context.Context, vm *jsonnet.VM, path string, tla []str
 	if expr == "" {
 		expr = "$"
 	}
-	pathURL, err := utils.PathToFileURL(path)
+	pathURL, err := utils.PathToURL(path)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubecfg/httpd.go
+++ b/pkg/kubecfg/httpd.go
@@ -17,7 +17,7 @@ type HttpdCmd struct {
 }
 
 func evaluateFile(vm *jsonnet.VM, path string) (string, error) {
-	pathURL, err := utils.PathToFileURL(path)
+	pathURL, err := utils.PathToURL(path)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
kubecfg already knows how to import files from various sources, like `http(s)` and `oci` urls. 

However, these urls are supported only from within `import` statements inside jsonnet and the CLI arguments accepted only files.
