### PR TITLE
Add support for inline code with -e

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -28,6 +28,7 @@ const (
 func init() {
 	RootCmd.AddCommand(deleteCmd)
 	deleteCmd.PersistentFlags().Int64(flagGracePeriod, -1, "Number of seconds given to resources to terminate gracefully. A negative value is ignored")
+	deleteCmd.PersistentFlags().StringP(flagExec, "e", "", "Inline code") // like `jsonnet -e`
 }
 
 var deleteCmd = &cobra.Command{
@@ -53,6 +54,14 @@ var deleteCmd = &cobra.Command{
 		c.DefaultNamespace, err = defaultNamespace(clientConfig)
 		if err != nil {
 			return err
+		}
+
+		exec, err := flags.GetString(flagExec)
+		if err != nil {
+			return err
+		}
+		if exec != "" {
+			args = append(args, toDataURL(exec))
 		}
 
 		objs, err := readObjs(cmd, args)

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -29,6 +29,7 @@ const (
 func init() {
 	diffCmd.PersistentFlags().String(flagDiffStrategy, "all", "Diff strategy, all, subset or last-applied")
 	diffCmd.PersistentFlags().Bool(flagOmitSecrets, false, "hide secret details when showing diff")
+	diffCmd.PersistentFlags().StringP(flagExec, "e", "", "Inline code") // like `jsonnet -e`
 	RootCmd.AddCommand(diffCmd)
 }
 
@@ -60,6 +61,14 @@ var diffCmd = &cobra.Command{
 		c.DefaultNamespace, err = defaultNamespace(clientConfig)
 		if err != nil {
 			return err
+		}
+
+		exec, err := flags.GetString(flagExec)
+		if err != nil {
+			return err
+		}
+		if exec != "" {
+			args = append(args, toDataURL(exec))
 		}
 
 		objs, err := readObjs(cmd, args)

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -35,6 +35,7 @@ func init() {
 	evalCmd.PersistentFlags().StringP(flagExpr, "e", "", "jsonnet expression to evaluate")
 	evalCmd.PersistentFlags().BoolP(flagShowKeys, "k", false, "instead of rendering an object, list it's keys")
 	evalCmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format.  Supported values are: json, yaml")
+	evalCmd.PersistentFlags().String(flagExec, "", "Inline code") // like `jsonnet -e`
 }
 
 func tlaNames(flags *pflag.FlagSet) ([]string, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -412,6 +412,10 @@ func dumpJSON(v interface{}) string {
 	return string(buf.Bytes())
 }
 
+func toDataURL(code string) string {
+	return fmt.Sprintf("data:,%s", url.PathEscape(code))
+}
+
 func getDynamicClients(cmd *cobra.Command) (dynamic.Interface, meta.RESTMapper, discovery.DiscoveryInterface, error) {
 	conf, err := clientConfig.ClientConfig()
 	if err != nil {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	flagFormat               = "format"
+	flagExec                 = "exec"
 	flagExportDir            = "export-dir"
 	flagExportFileNameFormat = "export-filename-format"
 	flagExportFileNameExt    = "export-filename-extension"
@@ -34,6 +35,7 @@ const (
 func init() {
 	RootCmd.AddCommand(showCmd)
 	showCmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format.  Supported values are: json, yaml")
+	showCmd.PersistentFlags().StringP(flagExec, "e", "", "Inline code") // like `jsonnet -e`
 	showCmd.PersistentFlags().String(flagExportDir, "", "Split yaml stream into multiple files and write files into a directory. If the directory exists it must be empty.")
 	showCmd.PersistentFlags().String(flagExportFileNameFormat, kubecfg.DefaultFileNameFormat, "Go template expression used to render path names for resources.")
 	showCmd.PersistentFlags().String(flagExportFileNameExt, "", fmt.Sprintf("Override the file extension used when creating filenames when using %s", flagExportFileNameFormat))
@@ -50,6 +52,13 @@ var showCmd = &cobra.Command{
 		outputFormat, err := flags.GetString(flagFormat)
 		if err != nil {
 			return err
+		}
+		exec, err := flags.GetString(flagExec)
+		if err != nil {
+			return err
+		}
+		if exec != "" {
+			args = append(args, toDataURL(exec))
 		}
 		exportDir, err := flags.GetString(flagExportDir)
 		if err != nil {

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -197,3 +197,34 @@ func TestShowUsingURLs(t *testing.T) {
 		t.Fatalf("got: %q, want: %q", got, want)
 	}
 }
+
+func TestShowExec(t *testing.T) {
+	const (
+		input = `{
+	apiVersion: "v1",
+	kind: "ConfigMap",
+	metadata: { name: "foo"},
+	data: { "foo": "bar" }
+}`
+
+		want = `{
+  "apiVersion": "v1",
+  "data": {
+    "foo": "bar"
+  },
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "foo"
+  }
+}
+`
+	)
+
+	got := cmdOutput(t, []string{"show", "-e", input})
+	defer resetFlagsOf(RootCmd)
+
+	if got != want {
+		t.Fatalf("got: %q, want: %q", got, want)
+	}
+
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -42,6 +42,7 @@ func init() {
 	updateCmd.PersistentFlags().Bool(flagDryRun, false, "Perform only read-only operations")
 	updateCmd.PersistentFlags().Bool(flagValidate, true, "Validate input against server schema")
 	updateCmd.PersistentFlags().Bool(flagIgnoreUnknown, false, "Don't fail validation if the schema for a given resource type is not found")
+	updateCmd.PersistentFlags().StringP(flagExec, "e", "", "Inline code") // like `jsonnet -e`
 }
 
 var updateCmd = &cobra.Command{
@@ -100,6 +101,14 @@ var updateCmd = &cobra.Command{
 			c.GcNamespace = metav1.NamespaceAll
 		} else {
 			c.GcNamespace = c.DefaultNamespace
+		}
+
+		exec, err := flags.GetString(flagExec)
+		if err != nil {
+			return err
+		}
+		if exec != "" {
+			args = append(args, toDataURL(exec))
 		}
 
 		objs, err := readObjs(cmd, args)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -31,6 +31,7 @@ func init() {
 	RootCmd.AddCommand(validateCmd)
 	validateCmd.PersistentFlags().Bool(flagIgnoreUnknown, true, "Don't fail if the schema for a given resource type is not found")
 	validateCmd.PersistentFlags().Bool(flagRepeatEval, true, "Repeat evaluation twice to verify idempotency")
+	validateCmd.PersistentFlags().StringP(flagExec, "e", "", "Inline code") // like `jsonnet -e`
 }
 
 var validateCmd = &cobra.Command{
@@ -56,6 +57,14 @@ var validateCmd = &cobra.Command{
 		repeatEval, err := flags.GetBool(flagRepeatEval)
 		if err != nil {
 			return err
+		}
+
+		exec, err := flags.GetString(flagExec)
+		if err != nil {
+			return err
+		}
+		if exec != "" {
+			args = append(args, toDataURL(exec))
 		}
 
 		objs, err := readObjs(cmd, args, utils.WithReadTwice(repeatEval))


### PR DESCRIPTION
(Please review but **do not merge** until the `url-cli` branch is merged)

The `jsonnet` CLI tool allows to run jsonnet code directly from the cli arguments instead of requiring it to be loaded from files.

e.g.:

```console
$ jsonnet -e "{apiVersion: 'v1', kind: 'ConfigMap', metadata: {name: 'foo'}}"   
{
   "apiVersion": "v1",
   "kind": "ConfigMap",
   "metadata": {
      "name": "foo"
   }
}
```

This PR gives `kubecfg` the same functionality:

```console
$ kubecfg show -e "{apiVersion: 'v1', kind: 'ConfigMap', metadata: {name: 'foo'}}"
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: foo
```

It can be useful to do things like:

```console
$ kubecfg update -e "(import 'foo.jsonnet') + (import 'overlay.jsonnet')"
```