### PR TITLE
Refactor common eval flags

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,0 +1,63 @@
+// Copyright 2023 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package cmd
+
+import (
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	flagExec = "exec"
+)
+
+type commonFlagOpts struct {
+	noShortEval bool
+}
+
+type commonEvalFlagOpt func(opts *commonFlagOpts)
+
+func withoutShortEvalFlag() commonEvalFlagOpt {
+	return func(opts *commonFlagOpts) {
+		opts.noShortEval = true
+	}
+}
+
+// Most commands evaluate jsonnet files and expose flags to control
+// how to evaluate them. We cannot put those flags in the root command because
+// we also have commands that wouldn't honour them.
+func addCommonEvalFlags(flags *flag.FlagSet, opt ...commonEvalFlagOpt) {
+	var opts commonFlagOpts
+	for _, o := range opt {
+		o(&opts)
+	}
+
+	shortEval := "e"
+	if opts.noShortEval {
+		shortEval = ""
+	}
+	flags.StringP(flagExec, shortEval, "", "Inline code") // like `jsonnet -e`
+}
+
+func processCommonEvalFlags(flags *flag.FlagSet, args *[]string) error {
+	exec, err := flags.GetString(flagExec)
+	if err != nil {
+		return err
+	}
+	if exec != "" {
+		*args = append(*args, toDataURL(exec))
+	}
+	return nil
+}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -36,8 +36,9 @@ func guessShell(path string) string {
 }
 
 func init() {
-	RootCmd.AddCommand(completionCmd)
-	completionCmd.PersistentFlags().String(flagShell, "", "Shell variant for which to generate completions.  Supported values are bash,zsh")
+	cmd := completionCmd
+	RootCmd.AddCommand(cmd)
+	cmd.PersistentFlags().String(flagShell, "", "Shell variant for which to generate completions.  Supported values are bash,zsh")
 }
 
 var completionCmd = &cobra.Command{

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -31,11 +31,13 @@ const (
 )
 
 func init() {
-	RootCmd.AddCommand(evalCmd)
-	evalCmd.PersistentFlags().StringP(flagExpr, "e", "", "jsonnet expression to evaluate")
-	evalCmd.PersistentFlags().BoolP(flagShowKeys, "k", false, "instead of rendering an object, list it's keys")
-	evalCmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format.  Supported values are: json, yaml")
-	evalCmd.PersistentFlags().String(flagExec, "", "Inline code") // like `jsonnet -e`
+	cmd := evalCmd
+	RootCmd.AddCommand(cmd)
+	cmd.PersistentFlags().StringP(flagExpr, "e", "", "jsonnet expression to evaluate")
+	cmd.PersistentFlags().BoolP(flagShowKeys, "k", false, "instead of rendering an object, list it's keys")
+	cmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format.  Supported values are: json, yaml")
+
+	addCommonEvalFlags(cmd.PersistentFlags(), withoutShortEvalFlag())
 }
 
 func tlaNames(flags *pflag.FlagSet) ([]string, error) {
@@ -88,7 +90,7 @@ var evalCmd = &cobra.Command{
 		}
 
 		if len(args) < 1 {
-			return fmt.Errorf("jsonent filename required")
+			return fmt.Errorf("jsonnet filename required")
 		}
 
 		tla, err := tlaNames(flags)

--- a/cmd/httpd.go
+++ b/cmd/httpd.go
@@ -29,8 +29,9 @@ const (
 )
 
 func init() {
-	RootCmd.AddCommand(httpdCmd)
-	httpdCmd.PersistentFlags().StringP(flagListenAddr, "l", ":8080", "address:port to listen")
+	cmd := httpdCmd
+	RootCmd.AddCommand(cmd)
+	cmd.PersistentFlags().StringP(flagListenAddr, "l", ":8080", "address:port to listen")
 }
 
 var httpdCmd = &cobra.Command{

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -29,9 +29,10 @@ const (
 )
 
 func init() {
-	RootCmd.AddCommand(packCmd)
-	packCmd.PersistentFlags().String(flagOutput, "", "Output archive file. Don't push to OCI but just dump into a file")
-	packCmd.PersistentFlags().Bool(flagInsecureRegistry, false, "Use HTTP instead of HTTPS to access the OCI registry")
+	cmd := packCmd
+	RootCmd.AddCommand(cmd)
+	cmd.PersistentFlags().String(flagOutput, "", "Output archive file. Don't push to OCI but just dump into a file")
+	cmd.PersistentFlags().Bool(flagInsecureRegistry, false, "Use HTTP instead of HTTPS to access the OCI registry")
 }
 
 var packCmd = &cobra.Command{


### PR DESCRIPTION
This is no-effect refactoring that will pave the way for adding more common flags to all the commands that evaluate some jsonnet  (update,show,eval,delete,validate)