### PR TITLE
Add --overlay flag

### DIFF
--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -226,5 +226,61 @@ func TestShowExec(t *testing.T) {
 	if got != want {
 		t.Fatalf("got: %q, want: %q", got, want)
 	}
+}
 
+func TestShowOverlay(t *testing.T) {
+	// TODO(mkm): fix the reset flags utilities.
+	// This hack ensures that any global state left over from other tests doesn't affect this test
+	// and that any global state left over from this test doesn't affect other tests
+	resetFlagsOf(RootCmd)
+	resetFlagsOf(showCmd)
+	defer resetFlagsOf(RootCmd)
+	defer resetFlagsOf(showCmd)
+
+	got := cmdOutput(t, []string{
+		"--alpha",
+		"show",
+		filepath.FromSlash("../testdata/configmap.jsonnet"),
+		filepath.FromSlash("../testdata/secret.jsonnet"),
+	})
+	want := `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test
+`
+
+	if got != want {
+		t.Fatalf("got: %q, want: %q", got, want)
+	}
+
+	got = cmdOutput(t, []string{
+		"--alpha",
+		"show",
+		filepath.FromSlash("../testdata/configmap.jsonnet"),
+		filepath.FromSlash("../testdata/secret.jsonnet"),
+		"--overlay",
+		filepath.FromSlash("../testdata/namespace-overlay.jsonnet")})
+	want = `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  namespace: myns
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test
+  namespace: myns
+`
+
+	if got != want {
+		t.Fatalf("got: %q, want: %q", got, want)
+	}
 }

--- a/examples/guestbook-overlay.jsonnet
+++ b/examples/guestbook-overlay.jsonnet
@@ -1,0 +1,11 @@
+{
+  master+: {
+    svc+: {
+      metadata+: {
+        labels+: {
+          demo: 'label',
+        },
+      },
+    },
+  },
+}

--- a/testdata/configmap.jsonnet
+++ b/testdata/configmap.jsonnet
@@ -1,0 +1,7 @@
+{
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: 'test',
+  },
+}

--- a/testdata/namespace-overlay.jsonnet
+++ b/testdata/namespace-overlay.jsonnet
@@ -1,0 +1,5 @@
+{
+  metadata+: {
+    namespace: 'myns',
+  },
+}

--- a/testdata/secret.jsonnet
+++ b/testdata/secret.jsonnet
@@ -1,0 +1,7 @@
+{
+  apiVersion: 'v1',
+  kind: 'Secret',
+  metadata: {
+    name: 'test',
+  },
+}


### PR DESCRIPTION
Implements an alpha feature that allows to apply overlays more easily. Demo:

```console
$ export KUBECFG_ALPHA=1
$ ./kubecfg show ./testdata/configmap.jsonnet
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
$ ./kubecfg show ./testdata/configmap.jsonnet --overlay ./testdata/namespace-overlay.jsonnet
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
  namespace: myns
```

This is basically a CLI syntactical sugar for:

```console
$  ./kubecfg show -e "(import './testdata/configmap.jsonnet') + (import './testdata/namespace-overlay.jsonnet')"
```

(which in turn is syntactical sugar for `kubecfg show 'data:,%28import%20%27...'`)

It works for all commands that accept jsonnet arguments (show,update,delete,validate,...).

If there are multiple jsonnet files, the same overlay is applied to all of the files. If you want more control over which overlay is applied on which file, you probably want to create intermediary files that import the source and the overlay