### PR TITLE
Fix resetFlags helper

### DIFF
--- a/cmd/pack_test.go
+++ b/cmd/pack_test.go
@@ -165,10 +165,7 @@ func TestPush(t *testing.T) {
 	testRef := fmt.Sprintf("%s/demo:1234", strings.TrimPrefix(testServer.URL, "http://"))
 	t.Logf("testRef=%q", testRef)
 
-	// The `--output ""` is necessary because our command testing harness is broken and preserves flag values from previous runs.
-	// We cannot easily test this from pkg/kubecfg because the helper that creates jsonnet VMs is intertwined with cobra commands/
-	// O-le-yak...
-	cmdOutput(t, []string{"--alpha", "pack", testRef, testRootFile, "--output", "", "--insecure-registry"})
+	cmdOutput(t, []string{"--alpha", "pack", testRef, testRootFile, "--insecure-registry"})
 
 	blobLock.Lock()
 	defer blobLock.Unlock()


### PR DESCRIPTION
1. make `resetFlagsOf()` recursively reset flags of subcommands
2. make `cmdOutput` reset flags after running the command
3. remove all explicit calls of resetFlags which are easy to forget
4. undo hack in pack_test.go