### PR TITLE
chore: Factor out JsonnetVM constructor

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/genuinetools/reg/registry"
 	jsonnet "github.com/google/go-jsonnet"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -40,6 +39,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
+	"github.com/kubecfg/kubecfg/pkg/kubecfg"
+	"github.com/kubecfg/kubecfg/pkg/kubecfg/vars"
 	"github.com/kubecfg/kubecfg/utils"
 
 	// Register auth plugins
@@ -209,10 +210,9 @@ func dirURL(path string) *url.URL {
 // JsonnetVM constructs a new jsonnet.VM, according to command line
 // flags
 func JsonnetVM(cmd *cobra.Command) (*jsonnet.VM, error) {
-	vm := jsonnet.MakeVM()
-	flags := cmd.Flags()
+	var opts []kubecfg.JsonnetVMOpt
 
-	var searchUrls []*url.URL
+	flags := cmd.Flags()
 
 	jpath := filepath.SplitList(os.Getenv("KUBECFG_JPATH"))
 
@@ -221,62 +221,35 @@ func JsonnetVM(cmd *cobra.Command) (*jsonnet.VM, error) {
 		return nil, err
 	}
 	jpath = append(jpath, jpathArgs...)
-
-	for _, p := range jpath {
-		p, err := filepath.Abs(p)
-		if err != nil {
-			return nil, err
-		}
-		searchUrls = append(searchUrls, dirURL(p))
-	}
+	opts = append(opts, kubecfg.WithImportPath(jpath...))
 
 	sURLs, err := flags.GetStringArray(flagJUrl)
 	if err != nil {
 		return nil, err
 	}
+	opts = append(opts, kubecfg.WithImportURLs(sURLs...))
 
-	// Special URL scheme used to find embedded content
-	sURLs = append(sURLs, "internal:///")
+	opts = append(opts, kubecfg.WithAlpha(viper.GetBool(flagAlpha)))
 
-	for _, ustr := range sURLs {
-		u, err := url.Parse(ustr)
-		if err != nil {
-			return nil, err
+	withVar := func(typ vars.Type, expr vars.ExpressionType, source vars.Source) func(string, string) {
+		return func(name, value string) {
+			opts = append(opts, kubecfg.WithVar(vars.New(typ, expr, source, name, value)))
 		}
-		if u.Path[len(u.Path)-1] != '/' {
-			u.Path = u.Path + "/"
-		}
-		searchUrls = append(searchUrls, u)
 	}
-
-	for _, u := range searchUrls {
-		log.Debugln("Jsonnet search path:", u)
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("Unable to determine current working directory: %v", err)
-	}
-
-	alpha := viper.GetBool(flagAlpha)
-	vm.Importer(utils.MakeUniversalImporter(searchUrls, alpha))
 
 	for _, spec := range []struct {
 		flagName string
-		inject   func(string, string)
-		isCode   bool
 		fromFile bool
+		setter   func(string, string)
 	}{
-		{flagExtVar, vm.ExtVar, false, false},
-		// Treat as code to evaluate "importstr":
-		{flagExtVarFile, vm.ExtCode, false, true},
-		{flagExtCode, vm.ExtCode, true, false},
-		{flagExtCodeFile, vm.ExtCode, true, true},
-		{flagTLAVar, vm.TLAVar, false, false},
-		// Treat as code to evaluate "importstr":
-		{flagTLAVarFile, vm.TLACode, false, true},
-		{flagTLACode, vm.TLACode, true, false},
-		{flagTLACodeFile, vm.TLACode, true, true},
+		{flagExtVar, false, withVar(vars.Ext, vars.String, vars.Literal)},
+		{flagExtVarFile, true, withVar(vars.Ext, vars.String, vars.File)},
+		{flagExtCode, false, withVar(vars.Ext, vars.Code, vars.Literal)},
+		{flagExtCodeFile, true, withVar(vars.Ext, vars.Code, vars.File)},
+		{flagTLAVar, false, withVar(vars.TLA, vars.String, vars.Literal)},
+		{flagTLAVarFile, true, withVar(vars.TLA, vars.String, vars.File)},
+		{flagTLACode, false, withVar(vars.TLA, vars.Code, vars.Literal)},
+		{flagTLACodeFile, true, withVar(vars.TLA, vars.Code, vars.File)},
 	} {
 		entries, err := flags.GetStringArray(spec.flagName)
 		if err != nil {
@@ -288,96 +261,23 @@ func JsonnetVM(cmd *cobra.Command) (*jsonnet.VM, error) {
 				if len(kv) != 2 {
 					return nil, fmt.Errorf("Failed to parse %s: missing '=' in %s", spec.flagName, entry)
 				}
-				// Ensure that the import path we construct here is absolute, so that our Importer
-				// won't try to glean from an extVar or TLA reference the context necessary to
-				// resolve a relative path.
-				path := kv[1]
-				if !filepath.IsAbs(path) {
-					path = filepath.Join(cwd, path)
-				}
-				u := &url.URL{Scheme: "file", Path: path}
-				var imp string
-				if spec.isCode {
-					imp = "import"
-				} else {
-					imp = "importstr"
-				}
-				spec.inject(kv[0], fmt.Sprintf("%s @'%s'", imp, strings.ReplaceAll(u.String(), "'", "''")))
+				spec.setter(kv[0], kv[1])
 			} else {
 				switch len(kv) {
 				case 1:
 					if v, present := os.LookupEnv(kv[0]); present {
-						spec.inject(kv[0], v)
+						spec.setter(kv[0], v)
 					} else {
 						return nil, fmt.Errorf("Missing environment variable: %s", kv[0])
 					}
 				case 2:
-					spec.inject(kv[0], kv[1])
+					spec.setter(kv[0], kv[1])
 				}
 			}
 		}
 	}
 
-	resolver, err := buildResolver(cmd)
-	if err != nil {
-		return nil, err
-	}
-
-	utils.RegisterNativeFuncs(vm, resolver)
-
-	return vm, nil
-}
-
-func buildResolver(cmd *cobra.Command) (utils.Resolver, error) {
-	flags := cmd.Flags()
-	resolver, err := flags.GetString(flagResolver)
-	if err != nil {
-		return nil, err
-	}
-	failAction, err := flags.GetString(flagResolvFail)
-	if err != nil {
-		return nil, err
-	}
-
-	ret := resolverErrorWrapper{}
-
-	switch failAction {
-	case "ignore":
-		ret.OnErr = func(error) error { return nil }
-	case "warn":
-		ret.OnErr = func(err error) error {
-			log.Warning(err.Error())
-			return nil
-		}
-	case "error":
-		ret.OnErr = func(err error) error { return err }
-	default:
-		return nil, fmt.Errorf("Bad value for --%s: %s", flagResolvFail, failAction)
-	}
-
-	switch resolver {
-	case "noop":
-		ret.Inner = utils.NewIdentityResolver()
-	case "registry":
-		ret.Inner = utils.NewRegistryResolver(registry.Opt{})
-	default:
-		return nil, fmt.Errorf("Bad value for --%s: %s", flagResolver, resolver)
-	}
-
-	return &ret, nil
-}
-
-type resolverErrorWrapper struct {
-	Inner utils.Resolver
-	OnErr func(error) error
-}
-
-func (r *resolverErrorWrapper) Resolve(image *utils.ImageName) error {
-	err := r.Inner.Resolve(image)
-	if err != nil {
-		err = r.OnErr(err)
-	}
-	return err
+	return kubecfg.JsonnetVM(opts...)
 }
 
 func readObjs(cmd *cobra.Command, paths []string, opts ...utils.ReadOption) ([]*unstructured.Unstructured, error) {

--- a/pkg/kubecfg/vars/vars.go
+++ b/pkg/kubecfg/vars/vars.go
@@ -1,0 +1,83 @@
+// Copyright 2023 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+// Types and constants pertaining to the various ways we can pass variables to a jsonnet VM engine.
+package vars
+
+import (
+	"fmt"
+
+	"github.com/google/go-jsonnet"
+)
+
+type Type int
+
+const (
+	// --ext-*
+	Ext Type = iota
+	// --tla-*
+	TLA
+)
+
+type ExpressionType int
+
+const (
+	// --*-str
+	String ExpressionType = iota
+	// --*-code
+	Code
+)
+
+type Source int
+
+const (
+	// --*-*
+	Literal Source = iota
+	// --*-*-file
+	File
+)
+
+type Var struct {
+	Typ    Type
+	Expr   ExpressionType
+	Source Source
+	Name   string
+	Value  string
+}
+
+func New(typ Type, expr ExpressionType, source Source, name, value string) Var {
+	return Var{typ, expr, source, name, value}
+}
+
+func (v *Var) Setter() func(*jsonnet.VM, string, string) {
+	// when the source type is file, the caller will turn the value into an "import" expression
+	// thus we need to call the "*Code" flavour.
+	mapping := map[Var]func(*jsonnet.VM, string, string){
+		{Ext, String, Literal, "", ""}: (*jsonnet.VM).ExtVar,
+		{Ext, String, File, "", ""}:    (*jsonnet.VM).ExtCode,
+		{Ext, Code, Literal, "", ""}:   (*jsonnet.VM).ExtCode,
+		{Ext, Code, File, "", ""}:      (*jsonnet.VM).ExtCode,
+
+		{TLA, String, Literal, "", ""}: (*jsonnet.VM).TLAVar,
+		{TLA, String, File, "", ""}:    (*jsonnet.VM).TLACode,
+		{TLA, Code, Literal, "", ""}:   (*jsonnet.VM).TLACode,
+		{TLA, Code, File, "", ""}:      (*jsonnet.VM).TLACode,
+	}
+	s, found := mapping[Var{v.Typ, v.Expr, v.Source, "", ""}]
+	if !found {
+		panic(fmt.Sprintf("internal error: didn't update Setter to match enum types: %#v", v))
+	}
+	return s
+}

--- a/pkg/kubecfg/vm.go
+++ b/pkg/kubecfg/vm.go
@@ -1,0 +1,230 @@
+// Copyright 2023 The kubecfg authors
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package kubecfg
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/genuinetools/reg/registry"
+	"github.com/google/go-jsonnet"
+	"github.com/kubecfg/kubecfg/pkg/kubecfg/vars"
+	"github.com/kubecfg/kubecfg/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+type jsonnetVMOpts struct {
+	alpha      bool
+	workingDir string
+	importPath []string
+	importURLs []string
+	vars       []vars.Var
+
+	resolverType          ResolverType
+	resolverFailureAction ResolverFailureAction
+}
+
+type JsonnetVMOpt func(*jsonnetVMOpts)
+
+func WithAlpha(enable bool) JsonnetVMOpt {
+	return func(opts *jsonnetVMOpts) {
+		opts.alpha = enable
+	}
+}
+
+func WithWorkingDir(dir string) JsonnetVMOpt {
+	return func(opts *jsonnetVMOpts) {
+		opts.workingDir = dir
+	}
+}
+
+func WithImportPath(importPath ...string) JsonnetVMOpt {
+	return func(opts *jsonnetVMOpts) {
+		opts.importPath = importPath
+	}
+}
+
+func WithImportURLs(importURLs ...string) JsonnetVMOpt {
+	return func(opts *jsonnetVMOpts) {
+		opts.importURLs = importURLs
+	}
+}
+
+func WithVar(v vars.Var) JsonnetVMOpt {
+	return func(opts *jsonnetVMOpts) {
+		opts.vars = append(opts.vars, v)
+	}
+}
+
+type ResolverType int
+
+const (
+	NoopResolver ResolverType = iota
+	RegistryResolver
+)
+
+type ResolverFailureAction int
+
+const (
+	IgnoreResolverError ResolverFailureAction = iota
+	WarnResolverError
+	ReportResolverError
+)
+
+func WithResolver(typ ResolverType, failureMode ResolverFailureAction) JsonnetVMOpt {
+	return func(opts *jsonnetVMOpts) {
+		opts.resolverType = typ
+		opts.resolverFailureAction = failureMode
+	}
+}
+
+// JsonnetVM constructs a new jsonnet.VM, according to command line
+// flags
+func JsonnetVM(opt ...JsonnetVMOpt) (*jsonnet.VM, error) {
+	vm := jsonnet.MakeVM()
+
+	var opts jsonnetVMOpts
+	for _, o := range opt {
+		o(&opts)
+	}
+
+	var searchUrls []*url.URL
+	for _, p := range opts.importPath {
+		p, err := filepath.Abs(p)
+		if err != nil {
+			return nil, err
+		}
+		searchUrls = append(searchUrls, dirURL(p))
+	}
+
+	sURLs := opts.importURLs
+	// Special URL scheme used to find embedded content
+	sURLs = append(sURLs, "internal:///")
+
+	for _, ustr := range sURLs {
+		u, err := url.Parse(ustr)
+		if err != nil {
+			return nil, err
+		}
+		if u.Path[len(u.Path)-1] != '/' {
+			u.Path = u.Path + "/"
+		}
+		searchUrls = append(searchUrls, u)
+	}
+
+	for _, u := range searchUrls {
+		log.Debugln("Jsonnet search path:", u)
+	}
+
+	if opts.workingDir == "" {
+		var err error
+		opts.workingDir, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("unable to determine current working directory: %w", err)
+		}
+	}
+
+	cwd := opts.workingDir
+	for _, v := range opts.vars {
+		name, value := v.Name, v.Value
+
+		if v.Source == vars.File {
+			// Ensure that the import path we construct here is absolute, so that our Importer
+			// won't try to glean from an extVar or TLA reference the context necessary to
+			// resolve a relative path.
+			path := value
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(cwd, path)
+			}
+			u := &url.URL{Scheme: "file", Path: path}
+			var imp string
+			if v.Expr == vars.Code {
+				imp = "import"
+			} else {
+				imp = "importstr"
+			}
+
+			value = fmt.Sprintf("%s @'%s'", imp, strings.ReplaceAll(u.String(), "'", "''"))
+		}
+
+		v.Setter()(vm, name, value)
+	}
+
+	vm.Importer(utils.MakeUniversalImporter(searchUrls, opts.alpha))
+
+	resolver, err := buildResolver(&opts)
+	if err != nil {
+		return nil, err
+	}
+	utils.RegisterNativeFuncs(vm, resolver)
+
+	return vm, nil
+}
+
+func buildResolver(opts *jsonnetVMOpts) (utils.Resolver, error) {
+	ret := resolverErrorWrapper{}
+
+	switch action := opts.resolverFailureAction; action {
+	case IgnoreResolverError:
+		ret.OnErr = func(error) error { return nil }
+	case WarnResolverError:
+		ret.OnErr = func(err error) error {
+			log.Warning(err.Error())
+			return nil
+		}
+	case ReportResolverError:
+		ret.OnErr = func(err error) error { return err }
+	default:
+		return nil, fmt.Errorf("bad value %d for resolver failure mode", action)
+	}
+
+	switch resolver := opts.resolverType; resolver {
+	case NoopResolver:
+		ret.Inner = utils.NewIdentityResolver()
+	case RegistryResolver:
+		ret.Inner = utils.NewRegistryResolver(registry.Opt{})
+	default:
+		return nil, fmt.Errorf("bad value %d for resolver tyoe", resolver)
+	}
+
+	return &ret, nil
+}
+
+type resolverErrorWrapper struct {
+	Inner utils.Resolver
+	OnErr func(error) error
+}
+
+func (r *resolverErrorWrapper) Resolve(image *utils.ImageName) error {
+	err := r.Inner.Resolve(image)
+	if err != nil {
+		err = r.OnErr(err)
+	}
+	return err
+}
+
+// NB: `path` is assumed to be in native-OS path separator form
+func dirURL(path string) *url.URL {
+	path = filepath.ToSlash(path)
+	if path[len(path)-1] != '/' {
+		// trailing slash is important
+		path = path + "/"
+	}
+	return &url.URL{Scheme: "file", Path: path}
+}


### PR DESCRIPTION
Currently the only way to create a jsonnet.VM with all the appropriate import hooks and whatnot is to call the JsonnetVM function in the `cmd` package, Unfortunately the cmd package is intimately tied to the cobra command+flag parsing framework which makes using kubecfg as a library from another project particularly painful, ugly and brittle.

kubecfg is more than just a cli around jsonnet; it adds import hooks for a few url formats (http, oci) and providers other features.

This PR is a first in a short series meant to make the kubecfg engine easier to use from other projects.

In particular, this PR moves `cmd.JsonnetVM(*cobra.Cmd)` into `kubecfg.JsonnetVM(opts...)`.
It lifts all the configurable bits into optional options (following Pike's option pattern https://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html).

It then keeps `cmd.Jsonnet(*cobra.Cmd)` but implements it in terms of `kubecfg.JsonnetVM`.

I intentionally tried to keep the code as similar in structure to the orignal, with only minor improvements.
Flag parsing (splitting the "=") and reading the env vars is kept in the `cmd` package. 

---

So far the local tests passed on a first try (suspicious); finger crossed for CI...