### PR TITLE
chore: Make ReadObjects public

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -285,20 +285,7 @@ func readObjs(cmd *cobra.Command, paths []string, opts ...utils.ReadOption) ([]*
 	if err != nil {
 		return nil, err
 	}
-
-	res := []*unstructured.Unstructured{}
-	for _, path := range paths {
-		objs, err := utils.Read(vm, path, opts...)
-		if err != nil {
-			return nil, fmt.Errorf("error reading %s: %v", path, err)
-		}
-
-		res = append(res, utils.FlattenToV1(objs)...)
-	}
-	if err := utils.CheckDuplicates(res); err != nil {
-		return nil, err
-	}
-	return res, nil
+	return kubecfg.ReadObjects(vm, paths, opts...)
 }
 
 // For debugging


### PR DESCRIPTION
This allows one to use kubecfg as a library. Example:

```go
	vm, err := kubecfg.JsonnetVM(kubecfg.WithImportPath("lib"))
	if err != nil {
		return nil, err
	}
	objs, err := kubecfg.ReadObjects(vm, paths, utils.WithProvenance(true))
	if err != nil {
		return nil, err
	}
```