### PR TITLE
Add support for #sha256:... fragment

### DIFF
--- a/utils/importer.go
+++ b/utils/importer.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -114,6 +116,19 @@ func (importer *universalImporter) Import(importedFrom, importedPath string) (js
 		tried = append(tried, foundAt)
 		importedData, err := importer.tryImport(foundAt, binary)
 		if err == nil {
+			if strings.HasPrefix(u.Fragment, "sha256:") {
+				desiredSha := strings.TrimPrefix(u.Fragment, "sha256:")
+				h := sha256.New()
+				h.Write(importedData.Data())
+				importedSha := hex.EncodeToString(h.Sum(nil))
+				if got, want := importedSha, desiredSha; got != want {
+					return jsonnet.Contents{}, "", fmt.Errorf("content hash mismatch: got: %q, want %q", got, want)
+				}
+			} else if u.Fragment != "" && u.Fragment != "#binary" {
+				// TODO(mkm) remove deprecated ##binary fragment and keep only u.Fragment != ""
+				return jsonnet.Contents{}, "", fmt.Errorf("unsupported fragment: %q", u.Fragment)
+			}
+
 			importer.cache[foundAt] = importedData
 			return importedData, foundAt, nil
 		} else if err != errNotFound {


### PR DESCRIPTION
```console
$ ./kubecfg show "file://$PWD/testdata/configmap.jsonnet#sha256:7871c163d6071da0289f4f20276f9e2a728ad2f82bd7e68361f986b53a585f22"     
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
$ ./kubecfg show "file://$PWD/testdata/configmap.jsonnet#sha256:7871c163d6071da0289f4f20276f9e2a728ad2f82bd7e68361f986b53a585f23"
ERROR error reading file:///Users/mkm/p/kubecfg/testdata/configmap.jsonnet#sha256:7871c163d6071da0289f4f20276f9e2a728ad2f82bd7e68361f986b53a585f23: content hash mismatch: got: "7871c163d6071da0289f4f20276f9e2a728ad2f82bd7e68361f986b53a585f22", want "7871c163d6071da0289f4f20276f9e2a728ad2f82bd7e68361f986b53a585f23"
```

Works for any url type.

You can use it to ensure that content you download is actually immutable:

```console
$ ./kubecfg show 'https://raw.githubusercontent.com/kubecfg/kubecfg/v0.29.1/testdata/configmap.jsonnet#sha256:'

ERROR error reading https://raw.githubusercontent.com/kubecfg/kubecfg/v0.29.1/testdata/configmap.jsonnet#sha256:: content hash mismatch: got: "7871c163d6071da0289f4f20276f9e2a728ad2f82bd7e68361f986b53a585f22", want ""
$ ./kubecfg show 'https://raw.githubusercontent.com/kubecfg/kubecfg/v0.29.1/testdata/configmap.jsonnet#sha256:7871c163d6071da0289f4f20276f9e2a728ad2f82bd7e68361f986b53a585f22'

---
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
```

This can be also useful if you want to use more readable symbolic tag names instead of github commit hashes (since tags are not necessarily immutable but often when used as release tags they are intended to be immutable)

TODO: tests