### PR TITLE
Accept .libsonnet files as jsonnet sources

### DIFF
--- a/utils/acquire.go
+++ b/utils/acquire.go
@@ -98,7 +98,7 @@ func Read(vm *jsonnet.VM, path string, opts ...ReadOption) ([]runtime.Object, er
 		}
 		defer f.Close()
 		return yamlReader(f)
-	case ".jsonnet":
+	case ".jsonnet", ".libsonnet":
 		return jsonnetReader(vm, path, opt)
 	}
 	return nil, fmt.Errorf("unknown file extension: %s", path)


### PR DESCRIPTION
```console
$ kubecfg show testdata/lib/test.libsonnet      
ERROR error reading testdata/lib/test.libsonnet: unknown file extension: testdata/lib/test.libsonnet
```

In the real world it's not uncommon to have `.libsonnet` files containing k8s objects you want to evaluate i.e. it's not like everybody only ever uses `.libsonnet` to keep strictly library stuff like functions etc. Sometimes people have a concept of a "component library", and decide that "libsonnet" file extension may well fit.

I'm not sure we're only supporting `.jsonnet` file extension for any reason other than not having explicitly added the `.libsonnet` extension to this switch case.