### PR TITLE
Systematize --overlay-* flags to follow pattern of --ext-var and --tla

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -16,12 +16,16 @@
 package cmd
 
 import (
-	flag "github.com/spf13/pflag"
+	"fmt"
+
+	"github.com/spf13/cobra"
 )
 
 const (
-	flagExec    = "exec"
-	flagOverlay = "overlay"
+	flagExec            = "exec"
+	flagOverlay         = "overlay" // deprecated
+	flagOverlayCode     = "overlay-code"
+	flagOverlayCodeFile = "overlay-code-file"
 )
 
 type commonFlagOpts struct {
@@ -39,7 +43,9 @@ func withoutShortEvalFlag() commonEvalFlagOpt {
 // Most commands evaluate jsonnet files and expose flags to control
 // how to evaluate them. We cannot put those flags in the root command because
 // we also have commands that wouldn't honour them.
-func addCommonEvalFlags(flags *flag.FlagSet, opt ...commonEvalFlagOpt) {
+func addCommonEvalFlags(cmd *cobra.Command, opt ...commonEvalFlagOpt) {
+	flags := cmd.PersistentFlags()
+
 	var opts commonFlagOpts
 	for _, o := range opt {
 		o(&opts)
@@ -51,4 +57,8 @@ func addCommonEvalFlags(flags *flag.FlagSet, opt ...commonEvalFlagOpt) {
 	}
 	flags.StringP(flagExec, shortEval, "", "Inline code") // like `jsonnet -e`
 	flags.String(flagOverlay, "", "Jsonnet file to compose to each of the input files")
+	flags.MarkDeprecated(flagOverlay, fmt.Sprintf("please use %s instead", flagOverlayCodeFile))
+	flags.String(flagOverlayCode, "", "Inline Jsonnet code to compose to each of the input files")
+	flags.String(flagOverlayCodeFile, "", "Jsonnet file to compose to each of the input files")
+	cmd.MarkFlagsMutuallyExclusive(flagOverlay, flagOverlayCode, flagOverlayCodeFile)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -30,7 +30,7 @@ func init() {
 	RootCmd.AddCommand(cmd)
 	cmd.PersistentFlags().Int64(flagGracePeriod, -1, "Number of seconds given to resources to terminate gracefully. A negative value is ignored")
 
-	addCommonEvalFlags(cmd.PersistentFlags())
+	addCommonEvalFlags(cmd)
 }
 
 var deleteCmd = &cobra.Command{

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -32,7 +32,7 @@ func init() {
 	cmd.PersistentFlags().String(flagDiffStrategy, "all", "Diff strategy, all, subset or last-applied")
 	cmd.PersistentFlags().Bool(flagOmitSecrets, false, "hide secret details when showing diff")
 
-	addCommonEvalFlags(cmd.PersistentFlags())
+	addCommonEvalFlags(cmd)
 }
 
 var diffCmd = &cobra.Command{

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -37,7 +37,7 @@ func init() {
 	cmd.PersistentFlags().BoolP(flagShowKeys, "k", false, "instead of rendering an object, list it's keys")
 	cmd.PersistentFlags().StringP(flagFormat, "o", "yaml", "Output format.  Supported values are: json, yaml")
 
-	addCommonEvalFlags(cmd.PersistentFlags(), withoutShortEvalFlag())
+	addCommonEvalFlags(cmd, withoutShortEvalFlag())
 }
 
 func tlaNames(flags *pflag.FlagSet) ([]string, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -291,17 +291,40 @@ func readObjs(cmd *cobra.Command, paths []string, opts ...utils.ReadOption) ([]*
 		paths = append(paths, utils.ToDataURL(exec))
 	}
 
+	overlayCodeFile, err := flags.GetString(flagOverlayCodeFile)
+	if err != nil {
+		return nil, err
+	}
+
 	overlay, err := flags.GetString(flagOverlay)
 	if err != nil {
 		return nil, err
 	}
 	if overlay != "" {
+		// deprecated. pflag will print a warning
+		overlayCodeFile = overlay
+	}
+
+	if overlayCodeFile != "" {
 		alpha := viper.GetBool(flagAlpha)
 		if !alpha {
-			return nil, fmt.Errorf("--%s is an alpha feature please use --%s", flagOverlay, flagAlpha)
+			return nil, fmt.Errorf("--%s is an alpha feature please use --%s", flagOverlayCodeFile, flagAlpha)
 		}
-		opts = append(opts, utils.WithOverlayURL(overlay))
+		opts = append(opts, utils.WithOverlayURL(overlayCodeFile))
 	}
+
+	overlayCode, err := flags.GetString(flagOverlayCode)
+	if err != nil {
+		return nil, err
+	}
+	if overlayCode != "" {
+		alpha := viper.GetBool(flagAlpha)
+		if !alpha {
+			return nil, fmt.Errorf("--%s is an alpha feature please use --%s", flagOverlayCode, flagAlpha)
+		}
+		opts = append(opts, utils.WithOverlayCode(overlayCode))
+	}
+
 	return readObjsInternal(cmd, paths, opts...)
 }
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -40,7 +40,7 @@ func init() {
 	cmd.PersistentFlags().String(flagExportFileNameExt, "", fmt.Sprintf("Override the file extension used when creating filenames when using %s", flagExportFileNameFormat))
 	cmd.PersistentFlags().Bool(flagShowProvenance, false, "Add provenance annotations showing the file and the field path to each rendered k8s object")
 
-	addCommonEvalFlags(cmd.PersistentFlags())
+	addCommonEvalFlags(cmd)
 }
 
 var showCmd = &cobra.Command{

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -44,7 +44,7 @@ func init() {
 	cmd.PersistentFlags().Bool(flagValidate, true, "Validate input against server schema")
 	cmd.PersistentFlags().Bool(flagIgnoreUnknown, false, "Don't fail validation if the schema for a given resource type is not found")
 
-	addCommonEvalFlags(cmd.PersistentFlags())
+	addCommonEvalFlags(cmd)
 }
 
 var updateCmd = &cobra.Command{

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -33,7 +33,7 @@ func init() {
 	cmd.PersistentFlags().Bool(flagIgnoreUnknown, true, "Don't fail if the schema for a given resource type is not found")
 	cmd.PersistentFlags().Bool(flagRepeatEval, true, "Repeat evaluation twice to verify idempotency")
 
-	addCommonEvalFlags(cmd.PersistentFlags())
+	addCommonEvalFlags(cmd)
 }
 
 var validateCmd = &cobra.Command{


### PR DESCRIPTION
The `--overlay` flag is an alpha feature that allows users to quickly apply an overlay on a jsonnet file, directly from the CLI.

During initial alpha testing of the feature, it became clear that we more often needed to apply an overlay where the jsonnet source of the overlay appears as literal code snippet in in the CLI flags (as opposed to applying an overlay from a file).

The rationale for that is that when you have overlays in files, it's more common to just import the file meant to be overlaid and then apply the overlay: `(import "base.jsonnet")  { foo: 1 }`.

That said, it's still useful to sometimes decouple the overlay from the files to overlay.

We have already an established flag pattern to distinguish "literal code" from "code from file", and we use it in the `--ext-*` and `--tla-*` flag families.

I propose to do the same with `--overlay-`, except there is no need to support `--overlay-str` since that would mean `base + "overlay"` which is not reasonable overlay to apply (technically it stringifies the base object and appends the string "overlay" right after the closing brace, which is not something anybody would actually want to do.

Thus I propose two flags;

*  `--overlay-code`: literal jsonnet code source
*  `--overlay-code-file`: pathname of a jsonnet file

And keep `--overlay` as an alias of `--overlay-code-file` but issue a deprecation warning.

The choice may appear a bit verbose, but it follows an established parameter and should be obvious to whoever has seen `--tla-code` etc

We should remove `--overlay` flag before promoting `--overlay-code-*` flags out of alpha.



