### PR TITLE
feat: Compatibility with ocireposource

### DIFF
--- a/pkg/kubecfg/pack.go
+++ b/pkg/kubecfg/pack.go
@@ -127,6 +127,12 @@ func (c PackCmd) pushOCIBundle(ctx context.Context, ref string, bodyBlob []byte,
 		Config:    configDesc,
 		Layers:    []ocispec.Descriptor{bodyDesc},
 		Versioned: specs.Versioned{SchemaVersion: 2},
+		Annotations: map[string]string{
+			// compatibility with fluxcd ocirepo source
+			"org.opencontainers.image.created":  "1970-01-01T00:00:00Z",
+			"org.opencontainers.image.revision": "unknown",
+			"org.opencontainers.image.source":   "kubecfg pack",
+		},
 	}
 	manifestBlob, err := json.Marshal(manifest)
 	if err != nil {


### PR DESCRIPTION
This allows the kubecfg jsonnet bundles to be ferried around by the fluxcd ocirepository controller.

```console
$ flux pull artifact oci://gcr.io/mkm-cloud/dummy:k1 -o /tmp/unpack
✔ source kubecfg pack
✔ revision unknown
✔ digest gcr.io/mkm-cloud/dummy@sha256:9d44fe2ee54fa7a6850bc46b3da7a37779f18bff832a07c77550773e39c1d1f6
✔ artifact content extracted to /tmp/unpack
$ tree /tmp/unpack
```