### PR TITLE
feat: add `validateJSONSchema` native function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -410,6 +410,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVPt6lD4/bhmzfiKo=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/lib/kubecfg.libsonnet
+++ b/lib/kubecfg.libsonnet
@@ -66,7 +66,7 @@
   // validateJSONSchema(obj, schema): Validates a given object against the provided
   // schema. Returns 'true' is the schema is valid. If this is not the case, an error stream
   // is omitted based on the given schema's rules.
-  validateJSONSchema(obj, schema):: std.native('validateJSONSchema')(obj, schema),
+  validateJSONSchema:: std.native('validateJSONSchema'),
 
   // isK8sObject(o): Return true iff o is a Kubernetes object.
   isK8sObject(o):: (

--- a/lib/kubecfg.libsonnet
+++ b/lib/kubecfg.libsonnet
@@ -16,78 +16,83 @@
 {
   // parseJson(data): parses the `data` string as a json document, and
   // returns the resulting jsonnet object.
-  parseJson:: std.native("parseJson"),
+  parseJson:: std.native('parseJson'),
 
   // parseYaml(data): parse the `data` string as a YAML stream, and
   // returns an *array* of the resulting jsonnet objects.  A single
   // YAML document will still be returned as an array with one
   // element.
-  parseYaml:: std.native("parseYaml"),
+  parseYaml:: std.native('parseYaml'),
 
   // manifestJson(value, indent): convert the jsonnet object `value`
   // to a string encoded as "pretty" (multi-line) JSON, with each
   // nesting level indented by `indent` spaces.
   manifestJson(value, indent=4):: (
-    local f = std.native("manifestJson");
+    local f = std.native('manifestJson');
     f(value, indent)
   ),
 
   // manifestYaml(value): convert the jsonnet object `value` to a
   // string encoded as a single YAML document.
-  manifestYaml:: std.native("manifestYaml"),
+  manifestYaml:: std.native('manifestYaml'),
 
   // escapeStringRegex(s): Quote the regex metacharacters found in s.
   // The result is a regex that will match the original literal
   // characters.
-  escapeStringRegex:: std.native("escapeStringRegex"),
+  escapeStringRegex:: std.native('escapeStringRegex'),
 
   // resolveImage(image): convert the docker image string from
   // image:tag into a more specific image@digest, depending on kubecfg
   // command line flags.
-  resolveImage:: std.native("resolveImage"),
+  resolveImage:: std.native('resolveImage'),
 
   // regexMatch(regex, string): Returns true if regex is found in
   // string. Regex is as implemented in golang regexp package
   // (python-ish).
-  regexMatch:: std.native("regexMatch"),
+  regexMatch:: std.native('regexMatch'),
 
   // regexSubst(regex, src, repl): Return the result of replacing
   // regex in src with repl.  Replacement string may include $1, etc
   // to refer to submatches.  Regex is as implemented in golang regexp
   // package (python-ish).
-  regexSubst:: std.native("regexSubst"),
+  regexSubst:: std.native('regexSubst'),
 
   // parseHelmChart(chartData, releaseName, namespace, values): Expand
   // helm chart into jsonnet objects.  `chartData` should be valid
   // chart .tgz as an array of numbers (bytes).  `values` is a jsonnet
   // object that conforms to a schema defined by the chart.
-  parseHelmChart:: std.native("parseHelmChart"),
+  parseHelmChart:: std.native('parseHelmChart'),
+
+  // validateJSONSchema(obj, schema): Validates a given object against the provided
+  // schema. Returns 'true' is the schema is valid. If this is not the case, an error stream
+  // is omitted based on the given schema's rules.
+  validateJSONSchema(obj, schema):: std.native('validateJSONSchema')(obj, schema),
 
   // isK8sObject(o): Return true iff o is a Kubernetes object.
   isK8sObject(o):: (
     std.isObject(o) &&
-    std.objectHas(o, "apiVersion") &&
-    std.objectHas(o, "kind")
+    std.objectHas(o, 'apiVersion') &&
+    std.objectHas(o, 'kind')
   ),
 
   // Private helper function for map/fold.
-  local isK8sList(o) = $.isK8sObject(o) && o.apiVersion == "v1" && o.kind == "List",
+  local isK8sList(o) = $.isK8sObject(o) && o.apiVersion == 'v1' && o.kind == 'List',
 
   // deepMap(func, o): Apply the given function to each Kubernetes
   // object in nested collection o, preserving the structure of o.
   deepMap(func, o):: (
     if isK8sList(o) then
-      o + {items: [func(item) for item in super.items]}
+      o { items: [func(item) for item in super.items] }
     else if $.isK8sObject(o) then
       func(o)
     else if std.isObject(o) then
-      {[k]: $.deepMap(func, o[k]) for k in std.objectFields(o)}
+      { [k]: $.deepMap(func, o[k]) for k in std.objectFields(o) }
     else if std.isArray(o) then
       [$.deepMap(func, elem) for elem in o]
     else if o == null then
       null
     else
-      error ("o must be an object or array of k8s objects, found " + std.type(o))
+      error ('o must be an object or array of k8s objects, found ' + std.type(o))
   ),
 
   // fold(func, o, init): Apply the given function to each Kubernetes
@@ -101,11 +106,11 @@
     else if std.isObject(o) then
       $.fold(func, [o[k] for k in std.objectFields(o)], init)
     else if std.isArray(o) then
-      std.foldl(function (running, elem) $.fold(func, elem, running), o, init)
+      std.foldl(function(running, elem) $.fold(func, elem, running), o, init)
     else if o == null then
       init
     else
-      error ("o must be an object or array of k8s objects, found " + std.type(o))
+      error ('o must be an object or array of k8s objects, found ' + std.type(o))
   ),
 
   layouts:: {
@@ -113,9 +118,9 @@
     // two-level collection of objects by 'apiVersion.kind'
     // (GroupVersionKind) and then object 'name'.  NB: use gvkNsName
     // if namespace is required for uniqueness.
-    gvkName(accum, o):: accum + {
-      [o.apiVersion + "." + o.kind]+: {
-        assert !(o.metadata.name in super),
+    gvkName(accum, o):: accum {
+      [o.apiVersion + '.' + o.kind]+: {
+        assert !( o.metadata.name in super),
         [o.metadata.name]: o,
       },
     },
@@ -124,10 +129,10 @@
     // three-level collection of objects by 'apiVersion.kind'
     // (GroupVersionKind), object 'namespace', and then object 'name'.
     // Namespace is '_' for non-namespaced objects.
-    gvkNsName(accum, o):: accum + {
-      [o.apiVersion + "." + o.kind]+: {
-        [std.get(o.metadata, "namespace", default="_")]+: {
-          assert !(o.metadata.name in super),
+    gvkNsName(accum, o):: accum {
+      [o.apiVersion + '.' + o.kind]+: {
+        [std.get(o.metadata, 'namespace', default='_')]+: {
+          assert !( o.metadata.name in super),
           [o.metadata.name]: o,
         },
       },

--- a/utils/nativefuncs.go
+++ b/utils/nativefuncs.go
@@ -253,18 +253,18 @@ func RegisterNativeFuncs(vm *jsonnet.VM, resolver Resolver) {
 
 			jSchema, err := json.Marshal(schema)
 			if err != nil {
-				return nil, fmt.Errorf("unable to json marshal schema: %w\n", err)
+				return nil, fmt.Errorf("unable to json marshal schema: %w", err)
 			}
 
 			// No URL defaults to draft 7 of JSONSchema
 			sch, err := jsonschema.CompileString("", string(jSchema))
 			if err != nil {
-				return false, fmt.Errorf("unable to compile jsonschema: %w\n", err)
+				return false, fmt.Errorf("unable to compile jsonschema: %w", err)
 			}
 
 			err = sch.Validate(obj)
 			if err != nil {
-				return nil, fmt.Errorf("object is invalid against the schema: %w\n", err)
+				return nil, fmt.Errorf("object is invalid against the schema: %w", err)
 			}
 
 			return true, nil

--- a/utils/nativefuncs.go
+++ b/utils/nativefuncs.go
@@ -264,7 +264,7 @@ func RegisterNativeFuncs(vm *jsonnet.VM, resolver Resolver) {
 
 			err = sch.Validate(obj)
 			if err != nil {
-				return false, fmt.Errorf("object is invalid against the schema: %w\n", err)
+				return nil, fmt.Errorf("object is invalid against the schema: %w\n", err)
 			}
 
 			return true, nil

--- a/utils/nativefuncs.go
+++ b/utils/nativefuncs.go
@@ -242,6 +242,22 @@ func RegisterNativeFuncs(vm *jsonnet.VM, resolver Resolver) {
 			return ret, nil
 		},
 	})
+
+	vm.NativeFunction(&jsonnet.NativeFunction{
+		Name:   "validate",
+		Params: []jsonnetAst.Identifier{"input", "schema"},
+		Func: func(args []interface{}) (res interface{}, err error) {
+
+			// Take input jsonnet
+			// validate against schema
+			// return true/false result
+
+			// input := args[0].(string)
+			// schema := args[1].(string)
+
+			return "", nil
+		},
+	})
 }
 
 func unmarshalYAMLString(yamlStr string) ([]interface{}, error) {

--- a/utils/nativefuncs_test.go
+++ b/utils/nativefuncs_test.go
@@ -18,6 +18,7 @@ package utils
 import (
 	"bytes"
 	"io"
+	"strings"
 	"testing"
 
 	jsonnet "github.com/google/go-jsonnet"
@@ -147,6 +148,56 @@ func TestParseHelmChart(t *testing.T) {
    "docker.io/bitnami/mysql:8.0.28-debian-10-r23"
 ]
 `)
+}
+
+func TestValidateJSONSchema(t *testing.T) {
+	vm := jsonnet.MakeVM()
+	RegisterNativeFuncs(vm, NewIdentityResolver())
+
+	res, err := vm.EvaluateSnippet("validObject", `
+    local schema = {
+      type: 'object',
+      properties: {
+        age: {
+          description: 'Age in years which must be equal to or greater than zero.',
+          type: 'integer',
+          minimum: 0,
+        },
+      },
+    };
+    local obj = {
+      age: 26,
+    };
+
+    std.native('validateJSONSchema')(obj, schema)`)
+	check(t, err, res, "true\n")
+
+	res, err = vm.EvaluateSnippet("invalidObjectErrors", `
+    local schema = {
+      type: 'object',
+      properties: {
+        projectName: {
+          description: 'projectName is required for the name of a project',
+          type: 'string',
+        },
+        language: {
+          description: 'Programming language implementation',
+          type: 'string',
+        },
+      },
+      required: ["projectName"],
+    };
+
+    local obj = {
+        language: 'go',
+    };
+
+    std.native('validateJSONSchema')(obj, schema)`)
+	if err != nil {
+		if !strings.Contains("invalid against schema", t.Error()) {
+			t.Errorf("expected invalid schema error. got: %s\n", err)
+		}
+	}
 }
 
 func TestArrayReader(t *testing.T) {

--- a/utils/nativefuncs_test.go
+++ b/utils/nativefuncs_test.go
@@ -194,8 +194,8 @@ func TestValidateJSONSchema(t *testing.T) {
 
     std.native('validateJSONSchema')(obj, schema)`)
 	if err != nil {
-		if !strings.Contains("invalid against schema", t.Error()) {
-			t.Errorf("expected invalid schema error. got: %s\n", err)
+		if !strings.Contains(err.Error(), "invalid against the schema") {
+			t.Errorf("expected invalid schema error. got: %s\n", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
Adds the `validateJSONSchema` functionality to `kubecfg` so that a schema can be provided against a particular object. If this validation fails, a stream of errors are produced to `stderr` - under the common `RUNTIME ERROR: ...`.

This is a little rough around the edges, so any feedback is appreciated :smile: 
