### PR TITLE
chore: Skip OCI push if PR comes from fork

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,8 +70,12 @@ jobs:
       - if: matrix.os == 'ubuntu-latest'
         uses: imjasonh/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
 
+      - name: Build OCI image using ko
+        if: matrix.os == 'ubuntu-latest' && github.event.pull_request.head.repo.fork
+        run: ko build -B --push=false --platform linux/amd64,linux/arm/v7,linux/arm64
+
       - name: Build OCI image using ko and push it to ghcr
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && !github.event.pull_request.head.repo.fork
         run: ko build -B --platform linux/amd64,linux/arm/v7,linux/arm64
 
   create_release:


### PR DESCRIPTION
PRs like https://github.com/kubecfg/kubecfg/pull/284 which come from forks, always fail their CI build because as part of the tests we build a docker image and push it to the GHCR repo. I like that feature because it allows me to test the images before merging a PR. But I don't know how to make the permissions work for PRs that come from forks.