### PR TITLE
chore: format files via go fmt

### DIFF
--- a/pkg/kubecfg/show_test.go
+++ b/pkg/kubecfg/show_test.go
@@ -18,8 +18,9 @@ import (
 
 // return sorted list of directory entries and the hash of their contents.
 // Example:
-//   ./foo/bar/baz.yaml:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
-//   ./foo/zar/aaa.yaml:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730
+//
+//	./foo/bar/baz.yaml:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+//	./foo/zar/aaa.yaml:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730
 func dirDigests(dir string) (res []string, err error) {
 	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if d.IsDir() {

--- a/pkg/kubecfg/update.go
+++ b/pkg/kubecfg/update.go
@@ -538,13 +538,13 @@ func getGcTagFromObj(obj metav1.Object) (bool, string) {
 	}
 }
 
-// gcTags: map is used as a set to lookup keys. The values are ignored. 
+// gcTags: map is used as a set to lookup keys. The values are ignored.
 func eligibleForGc(obj metav1.Object, gcTags map[string]bool) bool {
 	objectHasGcTag, objectGcTag := getGcTagFromObj(obj)
 
 	if objectHasGcTag {
-		_, objectGcTagInEligibleGcTags := gcTags[objectGcTag]	
-		
+		_, objectGcTagInEligibleGcTags := gcTags[objectGcTag]
+
 		return objectGcTagInEligibleGcTags
 	} else {
 		return false

--- a/utils/resolver.go
+++ b/utils/resolver.go
@@ -24,7 +24,7 @@ import (
 	"github.com/genuinetools/reg/repoutils"
 )
 
-const defaultRegistry = "registry-1.docker.io"	
+const defaultRegistry = "registry-1.docker.io"
 
 // ImageName represents the parts of a docker image name
 type ImageName struct {


### PR DESCRIPTION
Run `go fmt` across the project.

Building off of https://github.com/kubecfg/kubecfg/pull/284#issuecomment-1635617990, I (and likely others) have an automatic `go fmt` on save for a file.

Having this already done will avoid large, unrelated diffs when touching different files in the project.
