### PR TITLE
Fix Hook name to jsonnet code execution

### DIFF
--- a/pkg/kubecfg/httpd.go
+++ b/pkg/kubecfg/httpd.go
@@ -37,7 +37,7 @@ func (c HttpdCmd) Run(ctx context.Context, mkVM func() (*jsonnet.VM, error), pat
 
 		log.Infof("HTTPD Registering Hook: /%s - Filename: %s", base, filename)
 		http.HandleFunc(fmt.Sprint("/", base), func(w http.ResponseWriter, r *http.Request) {
-		  log.Infof("HTTPD Executing Hook: /%s - Filename: %s", base, filename)
+			log.Infof("HTTPD Executing Hook: /%s - Filename: %s", base, filename)
 
 			if r.Method != http.MethodPost {
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/pkg/kubecfg/httpd.go
+++ b/pkg/kubecfg/httpd.go
@@ -35,8 +35,10 @@ func (c HttpdCmd) Run(ctx context.Context, mkVM func() (*jsonnet.VM, error), pat
 		}
 		hookcode := string(filedata)
 
-		log.Infof("HTTPD Hook: /%s - Filename: %s", base, filename)
+		log.Infof("HTTPD Registering Hook: /%s - Filename: %s", base, filename)
 		http.HandleFunc(fmt.Sprint("/", base), func(w http.ResponseWriter, r *http.Request) {
+		  log.Infof("HTTPD Executing Hook: /%s - Filename: %s", base, filename)
+
 			if r.Method != http.MethodPost {
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 				return

--- a/pkg/kubecfg/httpd.go
+++ b/pkg/kubecfg/httpd.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"strings"
 
-  log "github.com/sirupsen/logrus"
 	"github.com/google/go-jsonnet"
 	"github.com/kubecfg/kubecfg/utils"
+	log "github.com/sirupsen/logrus"
 )
 
 // HttpdCmd represents the eval subcommand
@@ -19,23 +19,23 @@ type HttpdCmd struct {
 }
 
 func (c HttpdCmd) Run(ctx context.Context, mkVM func() (*jsonnet.VM, error), paths []string) error {
-  log.Info("Staring Kubecfg HTTPD")
+	log.Info("Staring Kubecfg HTTPD")
 	for _, path := range paths {
 
 		base := strings.TrimSuffix(path, ".jsonnet")
 
 		filename, err := utils.PathToURL(path)
 		if err != nil {
-      log.Fatalf("cannot convert path to filename %q: %v", path, err)
+			log.Fatalf("cannot convert path to filename %q: %v", path, err)
 		}
 
 		filedata, err := ioutil.ReadFile(path)
 		if err != nil {
-      log.Fatalf("cannot read filename %q: %v", path, err)
+			log.Fatalf("cannot read filename %q: %v", path, err)
 		}
 		hookcode := string(filedata)
 
-    log.Infof("HTTPD Hook: /%s - Filename: %s", base, filename)
+		log.Infof("HTTPD Hook: /%s - Filename: %s", base, filename)
 		http.HandleFunc(fmt.Sprint("/", base), func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/pkg/kubecfg/httpd.go
+++ b/pkg/kubecfg/httpd.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 
+  log "github.com/sirupsen/logrus"
 	"github.com/google/go-jsonnet"
 	"github.com/kubecfg/kubecfg/utils"
 )
@@ -16,23 +18,24 @@ type HttpdCmd struct {
 	ListenAddr string
 }
 
-func evaluateFile(vm *jsonnet.VM, path string) (string, error) {
-	pathURL, err := utils.PathToURL(path)
-	if err != nil {
-		return "", err
-	}
-	// TODO(mkm): figure out why vm.EvaluateFile and vm.EvaluateAnonymousSnippet don't work with our custom importers.
-	snippet := fmt.Sprintf("(import %q)", path)
-	jsonstr, err := vm.EvaluateSnippet(pathURL, snippet)
-	if err != nil {
-		return "", err
-	}
-	return jsonstr, nil
-}
-
 func (c HttpdCmd) Run(ctx context.Context, mkVM func() (*jsonnet.VM, error), paths []string) error {
+  log.Info("Staring Kubecfg HTTPD")
 	for _, path := range paths {
+
 		base := strings.TrimSuffix(path, ".jsonnet")
+
+		filename, err := utils.PathToURL(path)
+		if err != nil {
+      log.Fatalf("cannot convert path to filename %q: %v", path, err)
+		}
+
+		filedata, err := ioutil.ReadFile(path)
+		if err != nil {
+      log.Fatalf("cannot read filename %q: %v", path, err)
+		}
+		hookcode := string(filedata)
+
+    log.Infof("HTTPD Hook: /%s - Filename: %s", base, filename)
 		http.HandleFunc(fmt.Sprint("/", base), func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -50,7 +53,7 @@ func (c HttpdCmd) Run(ctx context.Context, mkVM func() (*jsonnet.VM, error), pat
 				return
 			}
 			vm.TLACode("request", string(body))
-			result, err := evaluateFile(vm, path)
+			result, err := vm.EvaluateSnippet(filename, hookcode)
 
 			if err != nil {
 				http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)


### PR DESCRIPTION
Move execution of `vm.evaluateSnippet` and resolution of `jsonnet filename` to the `Run `function.

**I am not sure why** but with the previous code when using `multiple jsonnet hooks` like 

`kubecfg --alpha httpd sync-hook1.jsonnet sync-hook2.jsonnet` the `last file` was always called for all hooks

then when hitting `:8080/sync-hook1` the `sync-hook2.jsonnet` was executed 

---

### example of the issue on  main 

* add Logging of HOOKs definition and execution
```
➜ git diff | cat
diff --git a/pkg/kubecfg/httpd.go b/pkg/kubecfg/httpd.go
index 567a05e..1b65957 100644
--- a/pkg/kubecfg/httpd.go
+++ b/pkg/kubecfg/httpd.go
@@ -7,6 +7,7 @@ import (
    "net/http"
    "strings"
 
+   log "github.com/sirupsen/logrus"
    "github.com/google/go-jsonnet"
    "github.com/kubecfg/kubecfg/utils"
 )
@@ -33,7 +34,9 @@ func evaluateFile(vm *jsonnet.VM, path string) (string, error) {
 func (c HttpdCmd) Run(ctx context.Context, mkVM func() (*jsonnet.VM, error), paths []string) error {
    for _, path := range paths {
        base := strings.TrimSuffix(path, ".jsonnet")
+       log.Infof("HTTPD Registering Hook: /%s - Filename: %s", base, path)
        http.HandleFunc(fmt.Sprint("/", base), func(w http.ResponseWriter, r *http.Request) {
+           log.Infof("HTTPD Executing Hook: /%s - Filename: %s", base, path)
            if r.Method != http.MethodPost {
                http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
                return
```

* start kubecfg httpd with 2 hooks and execute a curl like `curl -X POST -d @sync-mqtt-subscriber.jsonnet localhost:8080/sync-mqtt-subscriber` 
```
➜ /var/home/fciocchetti/Work/local/kubecfg/kubecfg --alpha httpd sync-mqtt-subscriber.jsonnet sync-mqtt-publisher.jsonnet

INFO  HTTPD Registering Hook: /sync-mqtt-subscriber - Filename: sync-mqtt-subscriber.jsonnet
INFO  HTTPD Registering Hook: /sync-mqtt-publisher - Filename: sync-mqtt-publisher.jsonnet
INFO  HTTPD Executing Hook: /sync-mqtt-subscriber - Filename: sync-mqtt-publisher.jsonnet

```
**^-** you can see that the `outer loop` registering hooks seems to have linked the right path to the right jsonnet but when the `http.handlefunc` is actually executed for `sync-mqtt-subscriber` hook the `sync-mqtt-publisher.jsonnet` code is actually exectued 

