### PR TITLE
Add build of docker image with TAG

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -78,6 +78,12 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && !github.event.pull_request.head.repo.fork
         run: ko build -B --platform linux/amd64,linux/arm/v7,linux/arm64
 
+      - name: Build OCI image using ko , tag and push it to ghcr
+        if: matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag=$(echo ${{ github.ref }} | cut -c11-)  # get tag name without tags/refs/ prefix.
+          ko build -B --platform linux/amd64,linux/arm/v7,linux/arm64 --tag-only --tags ${tag}
+
   create_release:
     name: Create Release
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,7 +68,7 @@ jobs:
           retention-days: 5
 
       - if: matrix.os == 'ubuntu-latest'
-        uses: imjasonh/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
+        uses: ko-build/setup-ko@v0.6
 
       - name: Build OCI image using ko
         if: matrix.os == 'ubuntu-latest' && github.event.pull_request.head.repo.fork

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -82,7 +82,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/tags/v')
         run: |
           tag=$(echo ${{ github.ref }} | cut -c11-)  # get tag name without tags/refs/ prefix.
-          ko build -B --platform linux/amd64,linux/arm/v7,linux/arm64 --tag-only --tags ${tag}
+          ko build -B --platform linux/amd64,linux/arm/v7,linux/arm64 --tags ${tag}
 
   create_release:
     name: Create Release


### PR DESCRIPTION
* Replace `setup-ko` action with official one from `ko-build` ( same version of binary is installed ) 
* Add a step to push image with `kubecfg:${GITHUB_TAG}` when the action is run on a tag / release


see build on my fork
![image](https://github.com/kubecfg/kubecfg/assets/2085772/126af60e-5c13-43bf-aff5-6f5793fe2c49)
