### PR TITLE
Add .ko.yaml configuration to set Build Flags

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,13 @@
+builds:
+- id: kubecfg
+  dir: .
+  main: .
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -tags
+  - netgo
+  - -installsuffix
+  - netgo
+  ldflags:
+  - -X main.version={{.Env.VERSION}} {{.Env.GO_LDFLAGS}}


### PR DESCRIPTION
* Add same flags we use through Makefile
  * "VERSION" and "GO_LDFLAGS" are already set in the workflow `go.yaml`
* Expose version in docker image 

```
➜ docker run --rm ghcr.io/primeroz/kubecfg/kubecfg:v0.0.2-fc-test1 version

kubecfg version: v0.0.2-fc-test1
jsonnet version: v0.20.0
```