### PR TITLE
fix: test short names and fix bug

### DIFF
--- a/pkg/kubecfg/pack.go
+++ b/pkg/kubecfg/pack.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path"
 	"sort"
 	"strings"
 
@@ -187,12 +188,14 @@ func shortNames(urls []*url.URL, rootURL *url.URL) ([]string, string) {
 	return s, strings.TrimPrefix(rootURL.Path, prefix)
 }
 
+// returns common directory part between various paths, including the trailing '/'.
+// If only one path is given, return its directory path
 func findCommonPathPrefix(paths []string) string {
 	if len(paths) == 0 {
 		return ""
 	}
 	if len(paths) == 1 {
-		return paths[0]
+		return path.Dir(paths[0]) + "/"
 	}
 
 	first, last := paths[0], paths[len(paths)-1]

--- a/pkg/kubecfg/pack_test.go
+++ b/pkg/kubecfg/pack_test.go
@@ -2,6 +2,8 @@ package kubecfg
 
 import (
 	"fmt"
+	"net/url"
+	"reflect"
 	"testing"
 )
 
@@ -22,6 +24,14 @@ func TestFindCommonPathPrefix(t *testing.T) {
 			[]string{"/foo/bar/a/b", "/foo/bar/a/c", "/foo/bar/c/a", "/fox/zar/c/a"},
 			"/",
 		},
+		{
+			[]string{"/foo/bar/file1.txt", "/foo/bar/file1.txt"},
+			"/foo/bar/",
+		},
+		{
+			[]string{"/foo/bar/file1.txt"},
+			"/foo/bar/",
+		},
 	}
 
 	for i, tc := range testCases {
@@ -32,4 +42,48 @@ func TestFindCommonPathPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestShortNames(t *testing.T) {
+	testCases := []struct {
+		urls            []string
+		rootURL         string
+		short           []string
+		shortEntrypoint string
+	}{
+		{
+			[]string{"file:///Users/mkm/tmp/dummy.txt", "file:///Users/mkm/tmp/shell.jsonnet"}, "file:///Users/mkm/tmp/shell.jsonnet",
+			[]string{"dummy.txt", "shell.jsonnet"}, "shell.jsonnet",
+		},
+		{
+			[]string{"file:///Users/mkm/tmp/shell.jsonnet"}, "file:///Users/mkm/tmp/shell.jsonnet",
+			[]string{"shell.jsonnet"}, "shell.jsonnet",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			var urls []*url.URL
+			for _, u := range tc.urls {
+				parsed, err := url.Parse(u)
+				if err != nil {
+					t.Fatal(err)
+				}
+				urls = append(urls, parsed)
+			}
+			rootURL, err := url.Parse(tc.rootURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			short, shortEntrypoint := shortNames(urls, rootURL)
+			if got, want := short, tc.short; !reflect.DeepEqual(got, want) {
+				t.Errorf("got: %q, want: %q", got, want)
+			}
+			if got, want := shortEntrypoint, tc.shortEntrypoint; got != want {
+				t.Errorf("got: %q, want: %q", got, want)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
`kubecfg pack` doesn't work when the jsonnet to pack has only one file.

```console
$ kubecfg pack --alpha gcr.io/mkm-cloud/package-demo:v1 $HOME/tmp/shell.jsonnet --output /tmp/output.tar.gz && tar tvfz /tmp/output.tar.gz
tar: Archive entry has empty or unreadable filename ... skipping.
tar: Error exit delayed from previous errors.
```

There is a bug in the function that strips the common directory parts.

This PR fixes the bug and adds a few test cases.

```console
$ go build && ./kubecfg pack --alpha gcr.io/mkm-cloud/package-demo:v1 $HOME/tmp/shell.jsonnet --output /tmp/output.tar.gz && tar tvfz /tmp/output.tar.gz
-rw-rw-rw-  0 0      0        1078 Jan  1  1970 shell.jsonnet