### PR TITLE
feat: kubecfg pack metadata. kubecfg version + custom metadata

### DIFF
--- a/cmd/pack_test.go
+++ b/cmd/pack_test.go
@@ -178,7 +178,7 @@ func TestPush(t *testing.T) {
 	// these digests have been observed by running the test failing and obverving the logs
 	const (
 		blobDigest = "sha256:90847d8bd5ca990ebf777bf131130cdcf695ace2f8bb59dee0571129af855f00"
-		confDigest = "sha256:918b7abf35db6a5e309be8760cca0e2c747cb186e03d7b32ed9f5da1d637f09f"
+		confDigest = "sha256:d5e1762d319a9de4f26f64420d485611ce6f1bdd4418e4d37d0b388ebc996fc0"
 	)
 	getBlob := func(key string) []byte {
 		got, ok := blobs[key]
@@ -190,7 +190,7 @@ func TestPush(t *testing.T) {
 
 	verifyBodyTarball(t, bytes.NewReader(getBlob(blobDigest)))
 
-	if got, want := string(getBlob(confDigest)), `{"entrypoint":"dir1/demo.jsonnet"}`; got != want {
+	if got, want := string(getBlob(confDigest)), `{"entrypoint":"dir1/demo.jsonnet","metadata":{"pack.kubecfg.dev/v1alpha1":{"version":"(dev build)"}}}`; got != want {
 		t.Errorf("got: %q, want: %q", got, want)
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,22 +17,16 @@ package cmd
 
 import (
 	"fmt"
-	"runtime/debug"
 
 	jsonnet "github.com/google/go-jsonnet"
+	kubecfgVersion "github.com/kubecfg/kubecfg/pkg/version"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/version"
+	k8sVersion "k8s.io/client-go/pkg/version"
 )
 
 func init() {
 	RootCmd.AddCommand(versionCmd)
 }
-
-// Default version if not overriden by build parameters.
-const DevVersion = "(dev build)"
-
-// Version is overridden by main
-var Version = DevVersion
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
@@ -40,14 +34,8 @@ var versionCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		out := cmd.OutOrStdout()
-		kubecfgVersion := Version
-		if bi, ok := debug.ReadBuildInfo(); ok {
-			if v := bi.Main.Version; v != "" && v != "(devel)" {
-				kubecfgVersion = v
-			}
-		}
-		fmt.Fprintln(out, "kubecfg version:", kubecfgVersion)
+		fmt.Fprintln(out, "kubecfg version:", kubecfgVersion.Get())
 		fmt.Fprintln(out, "jsonnet version:", jsonnet.Version())
-		fmt.Fprintln(out, "client-go version:", version.Get())
+		fmt.Fprintln(out, "client-go version:", k8sVersion.Get())
 	},
 }

--- a/main.go
+++ b/main.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/kubecfg/kubecfg/cmd"
 	"github.com/kubecfg/kubecfg/pkg/kubecfg"
+	pkgversion "github.com/kubecfg/kubecfg/pkg/version"
 )
 
 // Version is overridden using `-X main.version` during release builds
-var version = cmd.DevVersion
+var version = pkgversion.DevVersion
 
 func main() {
-	cmd.Version = version
+	pkgversion.Version = version
 
 	if err := cmd.RootCmd.Execute(); err != nil {
 		// PersistentPreRunE may not have been run for early

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,18 @@
+package version
+
+import "runtime/debug"
+
+// Default version if not overriden by build parameters.
+const DevVersion = "(dev build)"
+
+// Version is overridden by main
+var Version = DevVersion
+
+func Get() string {
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		if v := bi.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return Version
+}

--- a/utils/oci.go
+++ b/utils/oci.go
@@ -40,7 +40,8 @@ const (
 )
 
 type OCIBundleConfig struct {
-	Entrypoint string `json:"entrypoint"`
+	Entrypoint string          `json:"entrypoint"`
+	Metadata   json.RawMessage `json:"metadata,omitempty"`
 }
 
 type OCIBundle struct {


### PR DESCRIPTION
NOTE: `kubecfg pack` is still behind `--alpha` feature flag. This is an experiment.


When creating an OCI package with `kubecfg pack`, we currently record only the filename of the entrypoint in the metadata.

It would be useful to contain other metadata but we don't know yet which metadata will be useful.

This PR adds a `metadata` field in the bundle config which will contain a JSON object which should have top level keys scoped by metadata type, possibly tool specific.

For example:

```json
{
  "entrypoint": "shell.jsonnet",
  "metadata": {
    "kubit.kubecfg.dev/v1alpha1": {
      "minKubecfgVersion": "v0.30.0"
    },
    "pack.kubecfg.dev/v1alpha1": {
      "version": "v0.31.4"
    }
  }
}
```

The custom metadata is obtained by evaluating an `$._kubecfg_pack_metadata` expression on the root jsonnet and gracefully handling when that field doesn't exist.