### PR TITLE
feat(parseHelmChart): support passing capabilities

### DIFF
--- a/lib/kubecfg.libsonnet
+++ b/lib/kubecfg.libsonnet
@@ -57,11 +57,23 @@
   // package (python-ish).
   regexSubst:: std.native('regexSubst'),
 
-  // parseHelmChart(chartData, releaseName, namespace, values): Expand
+  // parseHelmChart(chartData, releaseName, namespace, values, capabilities={}): Expand
   // helm chart into jsonnet objects.  `chartData` should be valid
   // chart .tgz as an array of numbers (bytes).  `values` is a jsonnet
   // object that conforms to a schema defined by the chart.
-  parseHelmChart:: std.native('parseHelmChart'),
+  // `capabilities` is an object matching the struct format of Helm's
+  // "Capabilities" struct. Only "KubeVersion" is supported. For more
+  // information, see:
+  // https://helm.sh/docs/chart_template_guide/builtin_objects/
+  parseHelmChart(chartData, releaseName, namespace, values, capabilities={}):: (
+    std.native('parseHelmChart')(
+      chartData,
+      releaseName,
+      namespace,
+      values,
+      capabilities
+    )
+  ),
 
   // validateJSONSchema(obj, schema): Validates a given object against the provided
   // schema. Returns 'true' is the schema is valid. If this is not the case, an error stream

--- a/utils/nativefuncs_test.go
+++ b/utils/nativefuncs_test.go
@@ -114,12 +114,12 @@ func TestParseHelmChart(t *testing.T) {
 	vm := jsonnet.MakeVM()
 	RegisterNativeFuncs(vm, NewIdentityResolver())
 
-	_, err := vm.EvaluateSnippet("failtest", `std.native("parseHelmChart")("not_data", "rls", "myns", {})`)
+	_, err := vm.EvaluateSnippet("failtest", `std.native("parseHelmChart")("not_data", "rls", "myns", {}, {})`)
 	if err == nil {
 		t.Errorf("helmTemplate succeeded with invalid data")
 	}
 
-	_, err = vm.EvaluateSnippet("failtest", `std.native("parseHelmChart")([1, 2, 3, 256], "myrls", "myns", {})`)
+	_, err = vm.EvaluateSnippet("failtest", `std.native("parseHelmChart")([1, 2, 3, 256], "myrls", "myns", {}, {})`)
 	if err == nil {
 		t.Errorf("helmTemplate succeeded with invalid bytes")
 	}
@@ -128,7 +128,7 @@ func TestParseHelmChart(t *testing.T) {
 	RegisterNativeFuncs(vm, NewIdentityResolver())
 
 	x, err := vm.EvaluateSnippet("test", `
-    local chrt = std.native("parseHelmChart")(import "../testdata/mysql-8.8.26.tgz.bin", "myrls", "myns", {primary: {resources: {limits: {cpu: "2"}}}});
+    local chrt = std.native("parseHelmChart")(import "../testdata/mysql-8.8.26.tgz.bin", "myrls", "myns", {primary: {resources: {limits: {cpu: "2"}}}}, {});
     local ss = chrt["mysql/templates/primary/statefulset.yaml"][0];
     [
       // from nested chart


### PR DESCRIPTION
Updates `parseHelmChart` to support passing `capabilities` to be passed as `chartutil.Capabilities` to the helm chart renderer. Right now, only `KubeVersion` is able to be passed. This is important for rendering helm charts that conditionally render `apiVersion`s, among other fields, based on the current Kubernetes Cluster. The [default is `1.20`](https://github.com/helm/helm/blob/f31d4fb3aacabf6102b3ec9214b3433a3dbf1812/pkg/chartutil/capabilities.go#L31) which doesn't work for all use cases.

I wasn't sure if this is the best approach, nor is this currently an `optional` field (I will figure that out here soon). I wanted to send this out as proposal PR as well as to get feedback. We need this where I work currently, so I'm very motivated to get this working!

Thank you ✨