### PR TITLE
Use base image with shell

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,13 +1,14 @@
+defaultBaseImage: cgr.dev/chainguard/bash:latest
 builds:
-- id: kubecfg
-  dir: .
-  main: .
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -tags
-  - netgo
-  - -installsuffix
-  - netgo
-  ldflags:
-  - -X main.version={{.Env.VERSION}} {{.Env.GO_LDFLAGS}}
+  - id: kubecfg
+    dir: .
+    main: .
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -tags
+      - netgo
+      - -installsuffix
+      - netgo
+    ldflags:
+      - -X main.version={{.Env.VERSION}} {{.Env.GO_LDFLAGS}}


### PR DESCRIPTION
I need to run the kubecfg container an put the output in a file; I could add a flag just for that or I could just include bash in the image. The shell is likely useful for many other usecases of running kubecfg in a container.