### PR TITLE
fix: gate kustomize support behind alpha feature flag

### DIFF
--- a/utils/importer.go
+++ b/utils/importer.go
@@ -61,7 +61,7 @@ func MakeUniversalImporter(searchURLs []*url.URL, alpha bool) jsonnet.Importer {
 	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 	t.RegisterProtocol("internal", http.NewFileTransport(newInternalFS()))
 	t.RegisterProtocol("oci", newOCIImporter())
-	t.RegisterProtocol("kustomize+https", &kustomizeImporter{})
+	t.RegisterProtocol("kustomize+https", &kustomizeImporter{alpha: alpha})
 
 	return &universalImporter{
 		BaseSearchURLs: searchURLs,

--- a/utils/kustomize.go
+++ b/utils/kustomize.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -12,11 +13,17 @@ import (
 )
 
 // kustomizeImporter satifies the http.RoundTripper interface
-type kustomizeImporter struct{}
+type kustomizeImporter struct {
+	alpha bool
+}
 
 // RoundTrip performs a HTTP transaction for an `import kustomize+https://<url>` statement
 // by calling a simple Kustomize run against it, returning the rendered manifests.
 func (k *kustomizeImporter) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	if !k.alpha {
+		return nil, fmt.Errorf("kustomize+https:// prefix is an alpha feature, please use the --alpha flag")
+	}
 
 	// We know the scheme is kustomize+https, so simply grab the URL
 	// for kustomize to use


### PR DESCRIPTION
This was not previously behind the `--alpha` feature flag, when it should have been.

Now, we have an error when we do not use the `--alpha` feature flag with this, which is expected.

```
go run main.go show testdata/kustomize/test.jsonnet
ERROR error reading testdata/kustomize/test.jsonnet: RUNTIME ERROR: Get "kustomize+https://github.com/metacontroller/metacontroller/manifests/production": kustomize+https:// prefix is an alpha feature, please use the --alpha flag
        file:///home/influx/work/kubecfg/testdata/kustomize/test.jsonnet:2:27-115     object <anonymous>
        Field "metacontrollerUpstream"
        During manifestation
exit status 1

go run main.go show testdata/kustomize/test.jsonnet --alpha | head
---
apiVersion: v1
kind: Namespace
metadata:
  labels:
    app.kubernetes.io/name: metacontroller
  name: metacontroller
---
apiVersion: v1
...etc
```
