### PR TITLE
feat: Add --docs-tar-file flag to pack

### DIFF
--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -26,6 +26,7 @@ import (
 const (
 	flagOutput           = "output"
 	flagInsecureRegistry = "insecure-registry"
+	flagDocsTarFile      = "docs-tar-file"
 )
 
 func init() {
@@ -33,6 +34,7 @@ func init() {
 	RootCmd.AddCommand(cmd)
 	cmd.PersistentFlags().String(flagOutput, "", "Output archive file. Don't push to OCI but just dump into a file")
 	cmd.PersistentFlags().Bool(flagInsecureRegistry, false, "Use HTTP instead of HTTPS to access the OCI registry")
+	cmd.PersistentFlags().String(flagDocsTarFile, "", "Optional tar.gz file containing a documentation bundle")
 }
 
 var packCmd = &cobra.Command{
@@ -59,6 +61,11 @@ var packCmd = &cobra.Command{
 		}
 
 		c.InsecureRegistry, err = flags.GetBool(flagInsecureRegistry)
+		if err != nil {
+			return err
+		}
+
+		c.DocsTarFile, err = flags.GetString(flagDocsTarFile)
 		if err != nil {
 			return err
 		}

--- a/utils/oci.go
+++ b/utils/oci.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	OCIBundleBodyMediaType   = "application/vnd.kubecfg.bundle.tar+gzip"
+	OCIBundleDocsMediaType   = "application/vnd.kubecfg.bundle.docs.tar+gzip"
 	OCIBundleConfigMediaType = "application/vnd.kubecfg.bundle.config.v1+json"
 )
 


### PR DESCRIPTION
```console
$ ./kubecfg --alpha pack --insecure-registry localhost:5050/demo:v123 testdata/configmap.jsonnet --docs-tar-file demo.tgz
$ crane manifest --insecure localhost:5050/demo:v123 | jq
{
  "schemaVersion": 2,
  "config": {
    "mediaType": "application/vnd.kubecfg.bundle.config.v1+json",
    "digest": "sha256:2c388e6044e638e18c8ef4fb4593500db482b47fa4dc95fa7fc96209fb2aa428",
    "size": 101
  },
  "layers": [
    {
      "mediaType": "application/vnd.kubecfg.bundle.tar+gzip",
      "digest": "sha256:779e3aca133f6d8573ed50f2ab4d2e86eef7cf351a4142be6363e3720b2d823d",
      "size": 173
    },
    {
      "mediaType": "application/vnd.kubecfg.bundle.docs.tar+gzip",
      "digest": "sha256:de446e611755b322769e2f41fbaceb571f6db401efc6ff1475b5cb941bbef603",
      "size": 203631
    }
  ],
  "annotations": {
    "org.opencontainers.image.created": "1970-01-01T00:00:00Z",
    "org.opencontainers.image.revision": "unknown",
    "org.opencontainers.image.source": "kubecfg pack"
  }
}
```