### PR TITLE
feat: add `getPath`/`objectHasPath`/`objectHasPathAll` functions for access to nested objects

### DIFF
--- a/lib/kubecfg.libsonnet
+++ b/lib/kubecfg.libsonnet
@@ -158,9 +158,7 @@
 
   local objectHasDeep(o, f) = (
     local objectHasDeep_(o, ks) =
-      if !(std.type(o) == 'object' || std.type(o) == 'array') then
-        false
-      else if !std.objectHasAll(o, ks[0]) then
+      if !std.objectHasAll(o, ks[0]) then
         false
       else if std.length(ks) == 1 then
         true

--- a/lib/kubecfg.libsonnet
+++ b/lib/kubecfg.libsonnet
@@ -158,7 +158,9 @@
 
   local objectHasDeep(o, f) = (
     local objectHasDeep_(o, ks) =
-      if !std.objectHasAll(o, ks[0]) then
+      if !(std.type(o) == 'object' || std.type(o) == 'array') then
+        false
+      else if !std.objectHasAll(o, ks[0]) then
         false
       else if std.length(ks) == 1 then
         true

--- a/lib/kubecfg.libsonnet
+++ b/lib/kubecfg.libsonnet
@@ -156,9 +156,24 @@
     objectGetDeep_(o, std.split(f, '.'))
   ),
 
+  local objectHasDeep(o, f) = (
+    local objectHasDeep_(o, ks) =
+      if !std.objectHasAll(o, ks[0]) then
+        false
+      else if std.length(ks) == 1 then
+        true
+      else
+        objectHasDeep_(o[ks[0]], ks[1:]);
+
+    objectHasDeep_(o, std.split(f, '.'))
+  ),
+
   // Similar to std.get, but with a nested jsonpath.
   // If a value is not available, then a default is given
   getAtPath(obj, path, default):: objectGetDeep(obj, path, default),
+
+  // Similar to std.objectHasAll, but with a nested jsonpath.
+  hasAtPath(obj, path):: objectHasDeep(obj, path),
 
   layouts:: {
     // gvkName(accum, o): Helper for 'fold'.  This accumulates a

--- a/lib/kubecfg.libsonnet
+++ b/lib/kubecfg.libsonnet
@@ -144,6 +144,22 @@
       error ('o must be an object or array of k8s objects, found ' + std.type(o))
   ),
 
+  local objectGetDeep(o, f, default) = (
+    local objectGetDeep_(o, ks) =
+      if !std.objectHasAll(o, ks[0]) then
+        default
+      else if std.length(ks) == 1 then
+        o[ks[0]]
+      else
+        objectGetDeep_(o[ks[0]], ks[1:]);
+
+    objectGetDeep_(o, std.split(f, '.'))
+  ),
+
+  // Similar to std.get, but with a nested jsonpath.
+  // If a value is not available, then a default is given
+  getAtPath(obj, path, default):: objectGetDeep(obj, path, default),
+
   layouts:: {
     // gvkName(accum, o): Helper for 'fold'.  This accumulates a
     // two-level collection of objects by 'apiVersion.kind'

--- a/lib/kubecfg.libsonnet
+++ b/lib/kubecfg.libsonnet
@@ -181,7 +181,7 @@
   // jsonpath. If a value is not available, then a default or null is returned.
   getPath(obj, path, default=null, inc_hidden=true):: objectGetDeep(obj, path, default, inc_hidden),
 
-  // objectHasPath(obj path, inc_hidden): Similar to std.objectHasAll, but with a nested jsonpath.
+  // objectHasPath(obj, path, inc_hidden): Similar to std.objectHasAll, but with a nested jsonpath.
   objectHasPath(obj, path, inc_hidden=false):: objectHasDeep(obj, path, inc_hidden),
 
   // objectHasPathAll(obj path): Shorthand for objectHasPath(obj, path, inc_hidden=true)

--- a/testdata/kubecfg_test.jsonnet
+++ b/testdata/kubecfg_test.jsonnet
@@ -195,16 +195,24 @@ local result =
   std.assertEqual(two, { 'example.com/v1alpha1.Test': { _: { a: obj('a'), b: obj('b') } } }) &&
 
   local nested_obj = {
-      foo:: {
-          bar:: {
-              baz:: 'nested!'
-          }
-      }
+    foo: {
+      bar: {
+        baz: 'nested!',
+      },
+      hidden:: {
+        qux:: 'sneaky!',
+      },
+    },
   };
-  std.assertEqual(kubecfg.getAtPath(nested_obj, 'foo.bar.baz', 'default!'), 'nested!') &&
-  std.assertEqual(kubecfg.getAtPath(nested_obj, 'path.not.exist', 'default!'), 'default!') &&
-  std.assertEqual(kubecfg.hasAtPath(nested_obj, 'foo.bar.baz'), true) &&
-  std.assertEqual(kubecfg.hasAtPath(nested_obj, 'path.not.exist'), false) &&
+  std.assertEqual(kubecfg.getPath(nested_obj, 'foo.bar.baz'), 'nested!') &&
+  std.assertEqual(kubecfg.getPath(nested_obj, 'foo.hidden.qux'), 'sneaky!') &&
+  std.assertEqual(kubecfg.getPath(nested_obj, 'foo.hidden.qux', inc_hidden=false), null) &&
+  std.assertEqual(kubecfg.getPath(nested_obj, 'foo.not.exist', default="hello!"), "hello!") &&
+  std.assertEqual(kubecfg.getPath(nested_obj, 'path.not.exist', 'default!'), 'default!') &&
+  std.assertEqual(kubecfg.objectHasPath(nested_obj, 'foo.bar.baz'), true) &&
+  std.assertEqual(kubecfg.objectHasPath(nested_obj, 'foo.not.exist'), false) &&
+  std.assertEqual(kubecfg.objectHasPath(nested_obj, 'foo.hidden.qux'), false) &&
+  std.assertEqual(kubecfg.objectHasPathAll(nested_obj, 'foo.hidden.qux'), true) &&
 
   true;
 

--- a/testdata/kubecfg_test.jsonnet
+++ b/testdata/kubecfg_test.jsonnet
@@ -195,16 +195,20 @@ local result =
   std.assertEqual(two, { 'example.com/v1alpha1.Test': { _: { a: obj('a'), b: obj('b') } } }) &&
 
   local nested_obj = {
-      foo:: {
-          bar:: {
-              baz:: 'nested!'
-          }
-      }
+    foo:: {
+      bar:: {
+        baz:: 'nested!',
+      },
+    },
   };
   std.assertEqual(kubecfg.getAtPath(nested_obj, 'foo.bar.baz', 'default!'), 'nested!') &&
   std.assertEqual(kubecfg.getAtPath(nested_obj, 'path.not.exist', 'default!'), 'default!') &&
+  std.assertEqual(kubecfg.getAtPath({ foo: 10 }, 'foo', 1), 10) &&
+  std.assertEqual(kubecfg.getAtPath({ foo: 10 }, 'bar.baz', null), null) &&
   std.assertEqual(kubecfg.hasAtPath(nested_obj, 'foo.bar.baz'), true) &&
-  std.assertEqual(kubecfg.hasAtPath(nested_obj, 'path.not.exist'), false) &&
+  std.assertEqual(kubecfg.hasAtPath(nested_obj, 'foo.not.exist'), false) &&
+  std.assertEqual(kubecfg.hasAtPath({ foo: 10 }, 'foo.bar.baz'), false) &&
+  std.assertEqual(kubecfg.hasAtPath({ foo: 10 }, 'baz'), false) &&
 
   true;
 

--- a/testdata/kubecfg_test.jsonnet
+++ b/testdata/kubecfg_test.jsonnet
@@ -203,6 +203,8 @@ local result =
   };
   std.assertEqual(kubecfg.getAtPath(nested_obj, 'foo.bar.baz', 'default!'), 'nested!') &&
   std.assertEqual(kubecfg.getAtPath(nested_obj, 'path.not.exist', 'default!'), 'default!') &&
+  std.assertEqual(kubecfg.hasAtPath(nested_obj, 'foo.bar.baz'), true) &&
+  std.assertEqual(kubecfg.hasAtPath(nested_obj, 'path.not.exist'), false) &&
 
   true;
 

--- a/testdata/kubecfg_test.jsonnet
+++ b/testdata/kubecfg_test.jsonnet
@@ -195,20 +195,16 @@ local result =
   std.assertEqual(two, { 'example.com/v1alpha1.Test': { _: { a: obj('a'), b: obj('b') } } }) &&
 
   local nested_obj = {
-    foo:: {
-      bar:: {
-        baz:: 'nested!',
-      },
-    },
+      foo:: {
+          bar:: {
+              baz:: 'nested!'
+          }
+      }
   };
   std.assertEqual(kubecfg.getAtPath(nested_obj, 'foo.bar.baz', 'default!'), 'nested!') &&
   std.assertEqual(kubecfg.getAtPath(nested_obj, 'path.not.exist', 'default!'), 'default!') &&
-  std.assertEqual(kubecfg.getAtPath({ foo: 10 }, 'foo', 1), 10) &&
-  std.assertEqual(kubecfg.getAtPath({ foo: 10 }, 'bar.baz', null), null) &&
   std.assertEqual(kubecfg.hasAtPath(nested_obj, 'foo.bar.baz'), true) &&
-  std.assertEqual(kubecfg.hasAtPath(nested_obj, 'foo.not.exist'), false) &&
-  std.assertEqual(kubecfg.hasAtPath({ foo: 10 }, 'foo.bar.baz'), false) &&
-  std.assertEqual(kubecfg.hasAtPath({ foo: 10 }, 'baz'), false) &&
+  std.assertEqual(kubecfg.hasAtPath(nested_obj, 'path.not.exist'), false) &&
 
   true;
 

--- a/testdata/kubecfg_test.jsonnet
+++ b/testdata/kubecfg_test.jsonnet
@@ -194,6 +194,16 @@ local result =
   local two = kubecfg.layouts.gvkNsName(one, obj('b'));
   std.assertEqual(two, { 'example.com/v1alpha1.Test': { _: { a: obj('a'), b: obj('b') } } }) &&
 
+  local nested_obj = {
+      foo:: {
+          bar:: {
+              baz:: 'nested!'
+          }
+      }
+  };
+  std.assertEqual(kubecfg.getAtPath(nested_obj, 'foo.bar.baz', 'default!'), 'nested!') &&
+  std.assertEqual(kubecfg.getAtPath(nested_obj, 'path.not.exist', 'default!'), 'default!') &&
+
   true;
 
 // Kubecfg wants to see something that looks like a k8s object


### PR DESCRIPTION
This adds the following functions:
- `getPath(obj, path, default=null, inc_hidden=true)`
- `objectHasPath(obj, path, inc_hidden=false)`
- `objectHasPathAll(obj, path)`

into the `kubecfg.libsonnet` file.

This is shorthand for needing to do something which looks like this for nested objects:

```
if std.objectHas(myObj, "foo") && std.objectHas(myObj.foo, "bar") && ...
```

This was adapted from an [old jsonnet mailing list](https://groups.google.com/g/jsonnet/c/1nEJOYmS78I/m/uQ-g-9A3BwAJ) and morphed to be more inline with the standard library implementations for the respective `jsonnet` functions.