### PR TITLE
fix: remove duplicate err check

### DIFF
--- a/pkg/kubecfg/eval.go
+++ b/pkg/kubecfg/eval.go
@@ -32,10 +32,8 @@ func (c EvalCmd) Run(ctx context.Context, vm *jsonnet.VM, path string, tla []str
 	if err != nil {
 		return err
 	}
+
 	var eval string
-	if err != nil {
-		return err
-	}
 	if len(tla) > 0 {
 		formals := strings.Join(tla, ",")
 		pairs := make([]string, len(tla))


### PR DESCRIPTION
Remove the duplicate `err != nil` check here, the `pathURL` already has the check. I suspect that this is left over from a merge conflict sometime ago.

Spotted whilst I was browsing through for something else 😄 

This is probably easiest to show from the `main` branch:
https://github.com/kubecfg/kubecfg/blob/c8b7e6ade9a955af29fa5ac6eb18e3c7cc181872/pkg/kubecfg/eval.go#L31-L38