### PR TITLE
feat: --annotation cli arg for pack command

### DIFF
--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -27,6 +27,7 @@ const (
 	flagOutput           = "output"
 	flagInsecureRegistry = "insecure-registry"
 	flagDocsTarFile      = "docs-tar-file"
+	flagAnnotations      = "annotation"
 )
 
 func init() {
@@ -35,6 +36,7 @@ func init() {
 	cmd.PersistentFlags().String(flagOutput, "", "Output archive file. Don't push to OCI but just dump into a file")
 	cmd.PersistentFlags().Bool(flagInsecureRegistry, false, "Use HTTP instead of HTTPS to access the OCI registry")
 	cmd.PersistentFlags().String(flagDocsTarFile, "", "Optional tar.gz file containing a documentation bundle")
+	cmd.PersistentFlags().StringSlice(flagAnnotations, nil, "Annotations to add to the OCI image manifest")
 }
 
 var packCmd = &cobra.Command{
@@ -66,6 +68,11 @@ var packCmd = &cobra.Command{
 		}
 
 		c.DocsTarFile, err = flags.GetString(flagDocsTarFile)
+		if err != nil {
+			return err
+		}
+
+		c.Annotations, err = flags.GetStringSlice(flagAnnotations)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubecfg/pack.go
+++ b/pkg/kubecfg/pack.go
@@ -52,6 +52,7 @@ type PackCmd struct {
 	OutputFile       string
 	InsecureRegistry bool // use HTTP if true
 	DocsTarFile      string
+	Annotations      []string
 }
 
 func (c PackCmd) Run(ctx context.Context, vm *jsonnet.VM, ociPackage string, rootFile string) (err error) {
@@ -195,6 +196,15 @@ func (c PackCmd) pushOCIBundle(ctx context.Context, ref string, rootFile string,
 			"org.opencontainers.image.revision": revision,
 			"org.opencontainers.image.source":   "kubecfg pack",
 		},
+	}
+	if c.Annotations != nil {
+		for _, a := range c.Annotations {
+			parts := strings.SplitN(a, "=", 2)
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid annotation: %q", a)
+			}
+			manifest.Annotations[parts[0]] = parts[1]
+		}
 	}
 	manifestBlob, err := json.Marshal(manifest)
 	if err != nil {


### PR DESCRIPTION
closes #447 

e.g.:

```console
$ kubecfg --alpha pack \
  --annotation my-domain.com/my-repo-commit-sha=252e791916a082b075f6d84daf46ec8545482b7e648f8208f81f3f4e4c728a \
  --annotation my-domain.com/pull-request=https://github.com/my-org/my-repo/pull/123
```