### PR TITLE
ci: support linux/arm64 builds

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -107,7 +107,7 @@ jobs:
   release:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
     needs: create_release
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
i'm using `kubecfg` in a multi-platform image, built on self-hosted GitHub Actions runners. for some reason, one of the dependencies of `kubecfg` causes the `go install` to take a **very** long time (the whole image build takes 30 min; most of it is the `go install`).

if `kubecfg` published a linux arm build alongside the linux x64 build, then i could install both via `curl` instead of `go install`

refs:
  - [docs on linux arm runners](https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job#choosing-github-hosted-runners)