### PR TITLE
fix: update config mediaType

### DIFF
--- a/utils/oci.go
+++ b/utils/oci.go
@@ -37,7 +37,7 @@ import (
 const (
 	OCIBundleBodyMediaType      = "application/vnd.kubecfg.bundle.tar+gzip"
 	OCIBundleDocsMediaType      = "application/vnd.kubecfg.bundle.docs.tar+gzip"
-	OCIBundleConfigMediaType    = "application/vnd.oci.empty.v1+json"
+	OCIBundleConfigMediaType    = "application/vnd.oci.image.config.v1+json"
 	OCIBundleConfigArtifactType = "application/vnd.kubecfg.bundle.config.v1+json"
 )
 


### PR DESCRIPTION
Potential fix for https://github.com/influxdata/EAR/issues/6119. This will _hopefully_ update the config section of the manifest to have a mediaType that is supported by ECR. I'm not sure this is what we want broadly for this repo, so if we need to have automation that replaces the mediaType for clustered elsewhere, we could do that as well.

This will fix it for all upcoming releases, not for ones out already. For that we must manually fix it as described by Brandon here: https://influxdata.slack.com/archives/C0807RS4716/p1740765157917199